### PR TITLE
Dev

### DIFF
--- a/tgm-plugin-activation/auto-install.php
+++ b/tgm-plugin-activation/auto-install.php
@@ -2,16 +2,16 @@
 /**
  * Plugin installation and activation for WordPress themes.
  *
- * @package			TGM Plugin Activation
- * @version			1.1.0
- * @author			Thomas Griffin <thomas@thomasgriffinmedia.com>
- * @copyright			Copyright (c) 2011, Thomas Griffin
- * @license			http://opensource.org/licenses/gpl-3.0.php GPL v3
- * @link			https://github.com/thomasgriffin/TGM-Plugin-Activation
+ * @package	  TGM-Plugin-Activation
+ * @version	  1.1.0
+ * @author	  Thomas Griffin <thomas@thomasgriffinmedia.com>
+ * @copyright Copyright (c) 2011, Thomas Griffin
+ * @license	  http://opensource.org/licenses/gpl-3.0.php GPL v3
+ * @link      https://github.com/thomasgriffin/TGM-Plugin-Activation
  */
 
-
-/*  Copyright 2011  Thomas Griffin  (email : thomas@thomasgriffinmedia.com)
+/*
+    Copyright 2011  Thomas Griffin  (email : thomas@thomasgriffinmedia.com)
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License, version 3, as
@@ -25,20 +25,19 @@
     You should have received a copy of the GNU General Public License
     along with this program; if not, write to the Free Software
     Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
-
 */
 
-
-
-
 /**
- * Auto installation and activation class.
+ * Automatic plugin installation and activation class.
  *
- * Creates a new way to automatically install and activate plugins from within themes.
- * The plugins can be either pre-packaged or downloaded from the WordPress Plugin Repository.
+ * Creates a way to automatically install and activate plugins from within themes.
+ * The plugins can be either pre-packaged or downloaded from the WordPress
+ * Plugin Repository.
  *
+ * @since 1.0.0
+ *
+ * @package TGM-Plugin-Activation
  * @author Thomas Griffin <thomas@thomasgriffinmedia.com>
- * @author Gary Jones <gamajo@gamajo.com>
  */
 class TGM_Plugin_Activation {
 
@@ -89,6 +88,16 @@ class TGM_Plugin_Activation {
 	 */
 	var $default_path = '';
 
+	/**
+	 * Holds configurable array of strings.
+	 *
+	 * Default values are added in the constructor.
+	 *
+	 * @since 2.0.0
+	 *
+	 * @var array
+	 */
+	var $strings = array();
 
 	/**
 	 * Constructor.
@@ -103,6 +112,21 @@ class TGM_Plugin_Activation {
 	public function __construct() {
 
 		self::$instance =& $this;
+
+		$this->strings = array(
+			'page_title'             => __( 'Install Required Plugins', $this->domain ),
+			'menu_title'             => __( 'Install Plugins', $this->domain ),
+			'instructions_install'   => __( 'The %1$s plugin is required for this theme. Click on the big blue button below to install and activate %1$s.', $this->domain ),
+			'instructions_activate'  => __( 'The %1$s is installed but currently inactive. Please go to the <a href="%2$s">plugin administration page</a> page to activate it.', $this->domain ),
+			'button'                 => __( 'Install %s Now', $this->domain ),
+			'installing'             => __( 'Installing Plugin: %s', $this->domain ),
+			'oops'                   => __( 'Something went wrong.', $this->domain ),
+			'notice_can_install'     => __( 'This theme requires the %1$s plugin. <a href="%2$s"><strong>Click here to begin the installation process</strong></a>. You may be asked for FTP credentials based on your server setup.', $this->domain ),
+			'notice_cannot_install'  => __( 'Sorry, but you do not have the correct permissions to install the %s plugin. Contact the administrator of this site for help on getting the plugin installed.', $this->domain ),
+			'notice_can_activate'    => __( 'This theme requires the %1$s plugin. That plugin is currently inactive, so please go to the <a href="%2$s">plugin administration page</a> to activate it.', $this->domain ),
+			'notice_cannot_activate' => __( 'Sorry, but you do not have the correct permissions to activate the %s plugin. Contact the administrator of this site for help on getting the plugin activated.', $this->domain ),
+			'return'                 => __( 'Return to Required Plugins Installer', $this->domain ),
+		);
 
 		/** Annouce that the class is ready, and pass the object (for advanced use) */
 		do_action_ref_array( 'tgmpa_init', array( &$this ) );
@@ -164,11 +188,11 @@ class TGM_Plugin_Activation {
 			if ( ! is_plugin_active( $plugin['plugin'] ) ) {
 
 				add_theme_page(
-						__( 'Install Required Plugins', $this->domain ), // Page title
-						__( 'Install Plugins', $this->domain ),          // Menu title
-						'edit_theme_options',                            // Capability
-						$this->menu,                                     // Menu slug
-						array( &$this, 'install_plugins_page' )          // Callback
+						$this->strings['page_title'],           // Page title
+						$this->strings['menu_title'],           // Menu title
+						'edit_theme_options',                   // Capability
+						$this->menu,                            // Menu slug
+						array( &$this, 'install_plugins_page' ) // Callback
 				);
 				break;
 
@@ -209,27 +233,27 @@ class TGM_Plugin_Activation {
 
 				if ( ! isset( $installed_plugins[$plugin['plugin']] ) ) { // Plugin is not installed
 
-					_e( '<div class="instructions"><p>The <strong>' . $plugin['name'] . '</strong> plugin is required for this theme. Click on the big blue button below to install and activate <strong>' . $plugin['name'] . '</strong>.</p>', $this->domain );
+					echo '<div class="instructions"><p>' . sprintf( $this->strings['instructions_install'], '<strong>' . $plugin['name'] . '</strong>' ) . '</p></div>';
 
 				} elseif ( is_plugin_inactive( $plugin['plugin'] ) ) { // The plugin is installed but not active
 
-					_e( '<div class="instructions"><p>The <strong>' . $plugin['name'] . '</strong> is installed but currently inactive. Please go to the <a href="' . admin_url( 'plugins.php' ) . '">plugin administration page</a> page to activate it.</p></div>', $this->domain );
+					echo '<div class="instructions"><p>' . sprintf( $this->strings['instructions_activate'], '<strong>' . $plugin['name'] . '</strong>', admin_url( 'plugins.php' ) ) . '</p></div>';
 					continue; // No need to display a form because it is already installed, just needs to be activated
 
 				}
 				?>
 				<form action="" method="post">
 					<?php
-					wp_nonce_field( 'tgm_pa', 'tgm_pa_nonce' );
+					wp_nonce_field( 'tgmpa', 'tgmpa_nonce' );
 					submit_button(
 							sprintf(
-									__( 'Install %s Now', $this->domain ),
+									$this->strings['button'],
 									$plugin['name']
-							),                                              // Text
-							'primary',                                      // Type
-							sanitize_key( $plugin['name'] ),                // Name
-							true,                                           // Wrap
-							array()                                         // Other attributes
+							),                                // Text
+							'primary',                        // Type
+							sanitize_key( $plugin['name'] ),  // Name
+							true,                             // Wrap
+							array()                           // Other attributes
 					);
 					?>
 				</form>
@@ -262,7 +286,7 @@ class TGM_Plugin_Activation {
 		if ( empty( $_POST ) ) // Bail out if the global $_POST is empty
 			return false;
 
-		check_admin_referer( 'tgm_pa', 'tgm_pa_nonce' ); // Security check
+		check_admin_referer( 'tgmpa', 'tgmpa_nonce' ); // Security check
 
 		foreach ( $this->plugins as $plugin ) { // Iterate and perform the action for each plugin in the array
 
@@ -288,10 +312,10 @@ class TGM_Plugin_Activation {
 				$api = plugins_api( 'plugin_information', array( 'slug' => $plugin['plugin'], 'fields' => array( 'sections' => false ) ) );
 
 				if ( is_wp_error( $api ) )
-					wp_die( __( 'Something went wrong.', $this->domain ) . var_dump( $api ) );
+					wp_die( $this->strings['oops'] . var_dump( $api ) );
 
 				// Prep variables for Plugin_Installer_Skin class
-				$title = sprintf( __( 'Installing Plugin: %s', $this->domain ), $plugin['name'] );
+				$title = sprintf( $this->strings['installing'], $plugin['name'] );
 				$nonce = 'install-plugin_' . $plugin['plugin'];
 				$url = add_query_arg( array( 'action' => 'install-plugin', 'plugin' => $plugin['plugin'] ), 'update.php' );
 				if ( isset( $_GET['from'] ) )
@@ -338,7 +362,7 @@ class TGM_Plugin_Activation {
 		global $current_screen;
 
 		// Remove nag on the install pages
-		if ( 'appearance_page_install-required-plugins' == $current_screen->id )
+		if ( 'appearance_page_' . $this->menu == $current_screen->id )
 			return;
 
 		$installed_plugins = get_plugins(); // Retrieve a list of all the plugins
@@ -348,16 +372,16 @@ class TGM_Plugin_Activation {
 			if ( ! isset( $installed_plugins[$plugin['plugin']] ) ) { // Not installed
 
 				if ( current_user_can( 'install_plugins' ) )
-					$message = sprintf( __( 'This theme requires the %1$s plugin. <a href="%2$s"><strong>Click here to begin the installation process</strong></a>. You may be asked for FTP credentials based on your server setup.', $this->domain ), '<em>' . $plugin['name'] . '</em>', add_query_arg( 'page', $this->menu, admin_url( 'themes.php' ) ) );
+					$message = sprintf( $this->strings['notice_can_install'], '<em>' . $plugin['name'] . '</em>', add_query_arg( 'page', $this->menu, admin_url( 'themes.php' ) ) );
 				else // Need higher privileges to install the plugin
-					$message = sprintf( __( 'Sorry, but you do not have the correct permissions to install the %s plugin. Contact the administrator of this site for help on getting the plugin installed.', $this->domain ), '<em>' . $plugin['name'] . '</em>' );
+					$message = sprintf( $this->strings['notice_cannot_install'], '<em>' . $plugin['name'] . '</em>' );
 
 			} elseif ( is_plugin_inactive( $plugin['plugin'] ) ) { // Installed but not active
 
 				if ( current_user_can( 'activate_plugins' ) )
-					$message = sprintf( __( 'This theme requires the %1$s plugin. That plugin is currently inactive, so please go to the <a href="%2$s">plugin administration page</a> to activate it.', $this->domain ), '<em>' . $plugin['name'] . '</em>', admin_url( 'plugins.php' ) );
+					$message = sprintf( $this->strings['notice_can_activate'], '<em>' . $plugin['name'] . '</em>', admin_url( 'plugins.php' ) );
 				else // Need higher privileges to activate the plugin
-					$message = sprintf( __( 'Sorry, but you do not have the correct permissions to activate the %s plugin. Contact the administrator of this site for help on getting the plugin activated.', $this->domain ), '<em>' . $plugin['name'] . '</em>' );
+					$message = sprintf( $this->strings['notice_cannot_activate'], '<em>' . $plugin['name'] . '</em>' );
 
 			}
 			//printf( '<div class="updated"><p>%1$s</p></div>', $message );
@@ -382,7 +406,7 @@ class TGM_Plugin_Activation {
 		global $current_screen;
 
 		// Only load the CSS file on the Install page
-		if ( 'appearance_page_install-required-plugins' == $current_screen->id )
+		if ( 'appearance_page_' . $this->menu == $current_screen->id )
 			wp_enqueue_style( 'tgmpa-admin', get_stylesheet_directory_uri() . '/lib/tgm-plugin-activation/admin-css.css', array(), '1.1.0' );
 
 	}
@@ -403,6 +427,31 @@ class TGM_Plugin_Activation {
 	}
 
 	/**
+	 * Amend default configuration settings.
+	 *
+	 * @since 2.0.0
+	 *
+	 * @param array $config
+	 */
+	public function config( $config ) {
+
+		$keys = array( 'default_path', 'domain', 'menu', 'strings' );
+
+		foreach ( $keys as $key ) {
+			if( isset( $config[$key]) && $config[$key] ) {
+				if ( is_array( $config[$key] ) ) {
+					foreach ( $config[$key] as $subkey => $value )
+						$this->{$key}[$subkey] = $value;
+				} else {
+					$this->$key = $config[$key];
+				}
+			}
+
+		}
+
+	}
+
+	/**
 	 * Amend action link after plugin installation.
 	 *
 	 * @since 2.0.0
@@ -412,7 +461,7 @@ class TGM_Plugin_Activation {
 	 */
 	public function actions( $install_actions ) {
 
-		$install_actions['plugins_page'] = '<a href="' . add_query_arg( 'page', $this->menu, admin_url( 'themes.php' ) ) . '" title="' . esc_attr__( 'Return to Required Plugins Installer', $this->domain ) . '" target="_parent">' . __( 'Return to Required Plugins Installer', $this->domain ) . '</a>';
+		$install_actions['plugins_page'] = '<a href="' . add_query_arg( 'page', $this->menu, admin_url( 'themes.php' ) ) . '" title="' . esc_attr( $this->strings['return'] ) . '" target="_parent">' . __( 'Return to Required Plugins Installer', $this->domain ) . '</a>';
 		return $install_actions;
 
 	}
@@ -428,10 +477,14 @@ new TGM_Plugin_Activation;
  * @api
  *
  * @param array $plugins An array of plugin arrays
+ * @param array $config Optional. An array of configuration values
  */
-function tgmpa_register_plugins( $plugins ) {
+function tgmpa( $plugins, $config = array() ) {
 
 	foreach ( $plugins as $plugin )
 		TGM_Plugin_Activation::$instance->register( $plugin );
+
+	if ( $config )
+		TGM_Plugin_Activation::$instance->config( $config );
 
 }

--- a/tgm-plugin-activation/theme-file.php
+++ b/tgm-plugin-activation/theme-file.php
@@ -27,6 +27,7 @@ add_action( 'tgmpa_register', 'my_theme_register_required_plugins' );
  */
 function my_theme_register_required_plugins() {
 
+	/** Array of plugin arrays. Required keys are plugin, name and source. */
 	$plugins = array(
 		array(
 			'plugin' => 'tgm-example-plugin/tgm-example-plugin.php', // The main plugin file (including the plugin folder)
@@ -40,6 +41,36 @@ function my_theme_register_required_plugins() {
 		),
 	);
 
-	tgmpa_register_plugins( $plugins );
+	/** Change this to your theme text domain, used for internationalising strings */
+	$theme_text_domain = 'tgmpa';
+
+	/**
+	 * Array of configuration settings. Uncomment and amend each line as needed.
+	 * If you want the default strings to be available under your own theme domain,
+	 * uncomment the strings and domain.
+	 * Some of the strings are added into a sprintf, so see the comments at the
+	 * end of each line for what each argument will be.
+	 */
+	$config = array(
+		/*'domain'       => $theme_text_domain,         // Text domain - likely want to be the same as your theme. */
+		/*'default_path' => '',                         // Default absolute path to pre-packaged plugins */
+		/*'menu'         => 'install-my-theme-plugins', // Menu slug */
+		'strings'      => array(
+			/*'page_title'             => __( 'Install Required Plugins', $theme_text_domain ), // */
+			/*'menu_title'             => __( 'Install Plugins', $theme_text_domain ), // */
+			/*'instructions_install'   => __( 'The %1$s plugin is required for this theme. Click on the big blue button below to install and activate %1$s.', $theme_text_domain ), // %1$s = plugin name */
+			/*'instructions_activate'  => __( 'The %1$s is installed but currently inactive. Please go to the <a href="%2$s">plugin administration page</a> page to activate it.', $theme_text_domain ), // %1$s = plugin name, %2$s = plugins page URL */
+			/*'button'                 => __( 'Install %s Now', $theme_text_domain ), // %1$s = plugin name */
+			/*'installing'             => __( 'Installing Plugin: %s', $theme_text_domain ), // %1$s = plugin name */
+			/*'oops'                   => __( 'Something went wrong with the plugin API.', $theme_text_domain ), // */
+			/*'notice_can_install'     => __( 'This theme requires the %1$s plugin. <a href="%2$s"><strong>Click here to begin the installation process</strong></a>. You may be asked for FTP credentials based on your server setup.', $theme_text_domain ), // %1$s = plugin name, %2$s = TGMPA page URL */
+			/*'notice_cannot_install'  => __( 'Sorry, but you do not have the correct permissions to install the %s plugin. Contact the administrator of this site for help on getting the plugin installed.', $theme_text_domain ), // %1$s = plugin name */
+			/*'notice_can_activate'    => __( 'This theme requires the %1$s plugin. That plugin is currently inactive, so please go to the <a href="%2$s">plugin administration page</a> to activate it.', $theme_text_domain ), // %1$s = plugin name, %2$s = plugins page URL */
+			/*'notice_cannot_activate' => __( 'Sorry, but you do not have the correct permissions to activate the %s plugin. Contact the administrator of this site for help on getting the plugin activated.', $theme_text_domain ), // %1$s = plugin name */
+			/*'return'                 => __( 'Return to Required Plugins Installer', $theme_text_domain ), // */
+		),
+	);
+
+	tgmpa( $plugins, $config );
 
 }


### PR DESCRIPTION
Renamed the external function, added an optional second argument.
This argument is an array that accepts certain keys - if the keys match the supported list of
properties that can be set, then they are set.

All the strings in the class have been extracted into the $strings property.
Ideally, the sprintf arguments would not be split up from the string containing the placeholders,
but when setting the defaults (as in the theme-file.php example), variables like $plugin or $this->menu are not in scope.
Instead, comments have been added to the end of the example code, to show what each placeholder argument would be.
