### PR TITLE
PHP_CodeSniffer Code Standards

### DIFF
--- a/tgm-plugin-activation/class-tgm-plugin-activation.php
+++ b/tgm-plugin-activation/class-tgm-plugin-activation.php
@@ -123,9 +123,6 @@ class TGM_Plugin_Activation {
 		$this->strings = array(
 			'page_title'             			=> __( 'Install Required Plugins', $this->domain ),
 			'menu_title'             			=> __( 'Install Plugins', $this->domain ),
-			'instructions_install'   			=> __( 'The %1$s plugin is required for this theme. Click on the big blue button below to install and activate %1$s.', $this->domain ),
-			'instructions_install_recommended'	=> __( 'The %1$s plugin is recommended for this theme. Click on the big blue button below to install and activate %1$s.', $this->domain ),
-			'instructions_activate'  			=> __( 'The %1$s plugin is installed but currently inactive. Please go to the <a href="%2$s">plugin administration page</a> page to activate it.', $this->domain ),
 			'button'                 			=> __( 'Install %s Now', $this->domain ),
 			'installing'             			=> __( 'Installing Plugin: %s', $this->domain ),
 			'oops'                   			=> __( 'Something went wrong.', $this->domain ),
@@ -165,7 +162,6 @@ class TGM_Plugin_Activation {
 
 		/** Proceed only if we have plugins to handle */
 		if ( $this->plugins ) {
-
 			$sorted = array(); // Prepare variable for sorting
 
 			foreach ( $this->plugins as $plugin )
@@ -176,7 +172,7 @@ class TGM_Plugin_Activation {
 			add_action( 'admin_menu', array( &$this, 'admin_menu' ) );
 			add_action( 'admin_head', array( &$this, 'dismiss' ) );
 			add_filter( 'install_plugin_complete_actions', array( &$this, 'actions' ) );
-			
+
 			/** This fixes the admin bar not loading until after installation/activation is complete */
 			if ( $this->is_tgmpa_page() ) {
 				remove_action( 'wp_footer', 'wp_admin_bar_render', 1000 );
@@ -191,7 +187,6 @@ class TGM_Plugin_Activation {
 				add_action( 'admin_enqueue_scripts', array( &$this, 'thickbox' ) );
 				add_action( 'switch_theme', array( &$this, 'update_dismiss' ) );
 			}
-
 		}
 
 	}
@@ -217,12 +212,11 @@ class TGM_Plugin_Activation {
 	 * @return null Returns early if not the TGMPA page.
 	 */
 	public function admin_init() {
-		
+
 		if ( ! $this->is_tgmpa_page() )
 			return;
 
 		if ( isset( $_REQUEST['tab'] ) && 'plugin-information' == $_REQUEST['tab'] ) {
-
 			require_once ABSPATH . 'wp-admin/includes/plugin-install.php'; // Need for install_plugin_information()
 
 			wp_enqueue_style( 'plugin-install' );
@@ -233,7 +227,6 @@ class TGM_Plugin_Activation {
 			install_plugin_information();
 
 			exit;
-
 		}
 
 	}
@@ -278,20 +271,16 @@ class TGM_Plugin_Activation {
 		$this->populate_file_path();
 
 		foreach ( $this->plugins as $plugin ) {
-
 			if ( ! is_plugin_active( $plugin['file_path'] ) ) {
-
 				add_theme_page(
-						$this->strings['page_title'],           // Page title
-						$this->strings['menu_title'],           // Menu title
-						'edit_theme_options',                   // Capability
-						$this->menu,                            // Menu slug
-						array( &$this, 'install_plugins_page' ) // Callback
+					$this->strings['page_title'],           // Page title
+					$this->strings['menu_title'],           // Menu title
+					'edit_theme_options',                   // Capability
+					$this->menu,                            // Menu slug
+					array( &$this, 'install_plugins_page' ) // Callback
 				);
 				break;
-
 			}
-
 		}
 
 	}
@@ -307,10 +296,10 @@ class TGM_Plugin_Activation {
 	 * @return null Aborts early if we're processing a submission
 	 */
 	public function install_plugins_page() {
-			
+
 		if ( $this->do_plugin_install() )
 			return;
-			
+
 		?>
 		<div class="tgmpa wrap">
 		<?php
@@ -318,7 +307,7 @@ class TGM_Plugin_Activation {
 		?>
 		<h2><?php echo esc_html( get_admin_page_title() ); ?></h2>
 		<?php
-				
+
 			$plugin_table = new TGMPA_List_Table;
 			$plugin_table->prepare_items();
 
@@ -327,7 +316,7 @@ class TGM_Plugin_Activation {
             	<input type="hidden" name="page" value="<?php echo $this->menu; ?>" />
             	<?php $plugin_table->display(); ?>
         	</form>
-        	
+
 		</div>
 		<?php
 
@@ -352,17 +341,16 @@ class TGM_Plugin_Activation {
 	 * @return boolean True on success, false on failure
 	 */
 	protected function do_plugin_install() {
-		
-		$plugin = array(); 
-	
+
+		$plugin = array();
+
 		if ( isset( $_GET[sanitize_key( 'plugin' )] ) && ( isset( $_GET[sanitize_key( 'tgmpa-install' )] ) && 'install-plugin' == $_GET[sanitize_key( 'tgmpa-install' )] ) ) {
-			
 			check_admin_referer( 'tgmpa-install' );
-			
-			$plugin['name'] = $_GET[sanitize_key( 'plugin_name' )];
-			$plugin['slug'] = $_GET[sanitize_key( 'plugin' )];
+
+			$plugin['name']   = $_GET[sanitize_key( 'plugin_name' )];
+			$plugin['slug']   = $_GET[sanitize_key( 'plugin' )];
 			$plugin['source'] = $_GET[sanitize_key( 'plugin_source' )];
-			
+
 			$method = ''; // Leave blank so WP_Filesystem can populate it as necessary
 
 			$url = wp_nonce_url( 'themes.php?page=' . $this->menu, 'tgmpa-install' ); // Make sure we are coming from the right page
@@ -370,10 +358,8 @@ class TGM_Plugin_Activation {
 				return true;
 
 			if ( ! WP_Filesystem( $creds ) ) {
-
 				request_filesystem_credentials( $url, $method, true, false ); // Setup WP_Filesystem
 				return true;
-
 			}
 
 			require_once ABSPATH . 'wp-admin/includes/plugin-install.php'; // Need for plugins_api
@@ -387,7 +373,7 @@ class TGM_Plugin_Activation {
 			// Prep variables for Plugin_Installer_Skin class
 			$title = sprintf( $this->strings['installing'], $plugin['name'] );
 			$nonce = 'install-plugin_' . $plugin['slug'];
-			$url = add_query_arg( array( 'action' => 'install-plugin', 'plugin' => $plugin['slug'] ), 'update.php' );
+			$url   = add_query_arg( array( 'action' => 'install-plugin', 'plugin' => $plugin['slug'] ), 'update.php' );
 			if ( isset( $_GET['from'] ) )
 				$url .= add_query_arg( 'from', urlencode( stripslashes( $_GET['from'] ) ), $url );
 
@@ -395,12 +381,12 @@ class TGM_Plugin_Activation {
 				$plugin['source'] = $api->download_link;
 
 			/** Set type, based on whether the source starts with http:// or https:// */
-			$type = preg_match('|^http(s)?://|', $plugin['source'] ) ? 'web' : 'upload';
+			$type = preg_match( '|^http(s)?://|', $plugin['source'] ) ? 'web' : 'upload';
 
 			/** Prefix a default path to pre-packaged plugins */
 			$source = ( 'upload' == $type ) ? $this->default_path . $plugin['source'] : $plugin['source'];
 
-			$upgrader = new Plugin_Upgrader( new Plugin_Installer_Skin( compact( 'title', 'url', 'nonce', 'plugin', 'api' ) ) ); // Create a new instance of Plugin_Upgrader
+			$upgrader = new Plugin_Upgrader( $skin = new Plugin_Installer_Skin( compact( 'title', 'url', 'nonce', 'plugin', 'api' ) ) ); // Create a new instance of Plugin_Upgrader
 
 			$upgrader->install( $source ); // Perform the action and install the plugin from the $source urldecode()
 
@@ -421,37 +407,30 @@ class TGM_Plugin_Activation {
 				echo '<p>' . $this->strings['plugin_activated'] . '</p>';
 
 				foreach ( $this->plugins as $plugin ) {
-
 					if ( ! is_plugin_active( $plugin['file_path'] ) ) {
-
 						echo '<p><a href="' . add_query_arg( 'page', $this->menu, admin_url( 'themes.php' ) ) . '" title="' . esc_attr( $this->strings['return'] ) . '" target="_parent">' . __( 'Return to Required Plugins Installer', $this->domain ) . '</a></p>';
 						break;
-
 					}
-
 				}
-
 			}
 
 			return true;
-		
 		}
 		elseif ( isset( $_GET[sanitize_key( 'plugin' )] ) && ( isset( $_GET[sanitize_key( 'tgmpa-activate' )] ) && 'activate-plugin' == $_GET[sanitize_key( 'tgmpa-activate' )] ) ) {
-		
 			check_admin_referer( 'tgmpa-activate' );
-			
-			$plugin['name'] = $_GET[sanitize_key( 'plugin_name' )];
-			$plugin['slug'] = $_GET[sanitize_key( 'plugin' )];
+
+			$plugin['name']   = $_GET[sanitize_key( 'plugin_name' )];
+			$plugin['slug']   = $_GET[sanitize_key( 'plugin' )];
 			$plugin['source'] = $_GET[sanitize_key( 'plugin_source' )];
-			
+
 			$plugin_data = get_plugins( '/' . $plugin['slug'] );
-			
+
 			$plugin_file = array_keys( $plugin_data );
-			
+
 			$plugin_to_activate = $plugin['slug'] . '/' . $plugin_file[0];
-			
+
 			$activate = activate_plugin( $plugin_to_activate );
-		
+
 			if ( is_wp_error( $activate ) ) {
 				echo '<div id="message" class="error"><p>' . $activate->get_error_message() . '</p></div>';
 				echo '<p><a href="' . add_query_arg( 'page', $this->menu, admin_url( 'themes.php' ) ) . '" title="' . esc_attr( $this->strings['return'] ) . '" target="_parent">' . __( 'Return to Required Plugins Installer', $this->domain ) . '</a></p>';
@@ -461,9 +440,8 @@ class TGM_Plugin_Activation {
 				$msg = sprintf( __( 'Plugin %s activated', $this->domain ), '<strong>' . $plugin['name'] . '</strong>' );
 				echo '<div id="message" class="updated"><p>' . $msg . '</p></div>';
 			}
-			
 		}
-		
+
 		return false;
 
 	}
@@ -495,72 +473,65 @@ class TGM_Plugin_Activation {
 		$message = array(); // Store the messages in an array to be outputted after plugins have looped through
 
 		foreach ( $this->plugins as $plugin ) {
-
 			if ( is_plugin_active( $plugin['file_path'] ) ) // If the plugin is active, no need to display nag
 				continue;
 
-				if ( ! isset( $installed_plugins[$plugin['file_path']] ) ) { // Not installed
-
-					if ( current_user_can( 'install_plugins' ) ) {
-
-						if ( $plugin['required'] ) {
-							$message['notice_can_install_required'][] = $plugin['name'];
-						}
-						else { // This plugin is only recommended
-							$message['notice_can_install_recommended'][] = $plugin['name'];
-						}
-
-					} else { // Need higher privileges to install the plugin
-						$message['notice_cannot_install'][] = $plugin['name'];
-					}
-
-				} elseif ( is_plugin_inactive( $plugin['file_path'] ) ) { // Installed but not active
-
-					if ( current_user_can( 'activate_plugins' ) ) {
-
-						if ( $plugin['required'] ) {
-							$message['notice_can_activate_required'][] = $plugin['name'];
-						}
-						else { // This plugin is only recommended
-							$message['notice_can_activate_recommended'][] = $plugin['name'];
-						}
-
-					} else { // Need higher privileges to activate the plugin
-						$message['notice_cannot_activate'][] = $plugin['name'];
-					}
-
+			// Not installed
+			if ( ! isset( $installed_plugins[$plugin['file_path']] ) ) {
+				if ( current_user_can( 'install_plugins' ) ) {
+					if ( $plugin['required'] )
+						$message['notice_can_install_required'][] = $plugin['name'];
+					// This plugin is only recommended
+					else
+						$message['notice_can_install_recommended'][] = $plugin['name'];
 				}
-
+				// Need higher privileges to install the plugin
+				else {
+					$message['notice_cannot_install'][] = $plugin['name'];
+				}
+			}
+			// Installed but not active
+			elseif ( is_plugin_inactive( $plugin['file_path'] ) ) {
+				if ( current_user_can( 'activate_plugins' ) ) {
+					if ( $plugin['required'] )
+						$message['notice_can_activate_required'][] = $plugin['name'];
+					// This plugin is only recommended
+					else
+						$message['notice_can_activate_recommended'][] = $plugin['name'];
+				}
+				// Need higher privileges to activate the plugin
+				else {
+					$message['notice_cannot_activate'][] = $plugin['name'];
+				}
+			}
 		}
 
 		if ( ! get_user_meta( get_current_user_id(), 'tgmpa_dismissed_notice', true ) ) {
-
 			krsort( $message );
 
 			if ( ! empty( $message ) ) {
-
 				$rendered = ''; // Display all nag messages as strings
 
-				foreach ( $message as $type => $plugin_groups ) { // Grab all plugin names
-
+				// Grab all plugin names
+				foreach ( $message as $type => $plugin_groups ) {
 					$linked_plugin_groups = array();
 
-					/** Loop through the plugin names to make the ones pulled from the .org repo linked */
+					// Loop through the plugin names to make the ones pulled from the .org repo linked
 					foreach ( $plugin_groups as $plugin_group_single_name ) {
-
 						$source = $this->_get_plugin_data_from_name( $plugin_group_single_name, 'source' );
 						if ( ! $source || preg_match( '|^http://wordpress.org/extend/plugins/|', $source ) ) {
-
-							$url = add_query_arg( array(
-								'tab'       => 'plugin-information',
-								'plugin'    => $this->_get_plugin_data_from_name( $plugin_group_single_name ),
-								'TB_iframe' => 'true',
-								'width'     => '640',
-								'height'    => '500',
-							), admin_url( 'plugin-install.php' ) );
+							$url = add_query_arg(
+								array(
+									'tab'       => 'plugin-information',
+									'plugin'    => $this->_get_plugin_data_from_name( $plugin_group_single_name ),
+									'tb_iframe' => 'true',
+									'width'     => '640',
+									'height'    => '500',
+								),
+								admin_url( 'plugin-install.php' )
+							);
 
 							$linked_plugin_groups[] .= '<a href="' . $url . '" class="thickbox" title="' . $plugin_group_single_name . '">' . $plugin_group_single_name . '</a>';
-
 						}
 						else {
 							$linked_plugin_groups[] .= $plugin_group_single_name; // No hyperlink
@@ -568,31 +539,29 @@ class TGM_Plugin_Activation {
 
 						if ( isset( $linked_plugin_groups ) && (array) $linked_plugin_groups )
 							$plugin_groups = $linked_plugin_groups;
-
 					}
 
 					$last_plugin = array_pop( $plugin_groups ); // Pop off last name to prep for readability
-					$imploded = empty( $plugin_groups ) ? '<em>' . $last_plugin . '</em>' : '<em>' . ( implode( ', ', $plugin_groups ) . '</em> and <em>' . $last_plugin . '</em>' );
+					$imploded    = empty( $plugin_groups ) ? '<em>' . $last_plugin . '</em>' : '<em>' . ( implode( ', ', $plugin_groups ) . '</em> and <em>' . $last_plugin . '</em>' );
 
 					$rendered .= '<p>' . sprintf( $this->strings[$type], $imploded ) . '</p>'; // All messages now stored
-
 				}
 
 				/** Define all of the action links */
-				$action_links = apply_filters( 'tgmpa_notice_action_links', array(
-					'install'  => '<a href="' . add_query_arg( 'page', $this->menu, admin_url( 'themes.php' ) ) . '">' . __( 'Begin installing plugins', $this->domain ) . '</a>',
-					'activate' => '<a href="' . admin_url( 'plugins.php' ) . '">' . __( 'Activate installed plugins', $this->domain ) . '</a>',
-					'dismiss'  => '<a class="dismiss-notice" href="' . add_query_arg( 'tgmpa-dismiss', 'dismiss_admin_notices' ) . '" target="_parent">' . __( 'Dismiss this notice', $this->domain ) . '</a>' )
+				$action_links = apply_filters(
+					'tgmpa_notice_action_links',
+					array(
+						'install'  => '<a href="' . add_query_arg( 'page', $this->menu, admin_url( 'themes.php' ) ) . '">' . __( 'Begin installing plugins', $this->domain ) . '</a>',
+						'activate' => '<a href="' . admin_url( 'plugins.php' ) . '">' . __( 'Activate installed plugins', $this->domain ) . '</a>',
+						'dismiss'  => '<a class="dismiss-notice" href="' . add_query_arg( 'tgmpa-dismiss', 'dismiss_admin_notices' ) . '" target="_parent">' . __( 'Dismiss this notice', $this->domain ) . '</a>',
+					)
 				);
 
 				if ( $action_links )
 					$rendered .= '<p>' . implode( ' | ', $action_links ) . '</p>';
 
 				add_settings_error( 'tgmpa', 'tgmpa', $rendered, 'updated' );
-
-
 			}
-
 		}
 
 		/** Admin options pages already output settings_errors, so this is to avoid duplication */
@@ -645,7 +614,6 @@ class TGM_Plugin_Activation {
 		$keys = array( 'default_path', 'domain', 'notices', 'menu', 'strings' );
 
 		foreach ( $keys as $key ) {
-
 			if ( isset( $config[$key] ) ) {
 				if ( is_array( $config[$key] ) ) {
 					foreach ( $config[$key] as $subkey => $value )
@@ -654,7 +622,6 @@ class TGM_Plugin_Activation {
 					$this->$key = $config[$key];
 				}
 			}
-
 		}
 
 	}
@@ -809,7 +776,7 @@ function tgmpa( $plugins, $config = array() ) {
  */
 if ( ! class_exists( 'WP_List_Table' ) )
 	require_once( ABSPATH . 'wp-admin/includes/class-wp-list-table.php' );
-	
+
 /**
  * List table class for handling plugins.
  *
@@ -828,7 +795,7 @@ if ( ! class_exists( 'WP_List_Table' ) )
  * @author Gary Jones <gamajo@gamajo.com>
  */
 class TGMPA_List_Table extends WP_List_Table {
-	
+
 	/**
 	 * References parent constructor and sets defaults for class.
 	 *
@@ -842,64 +809,66 @@ class TGMPA_List_Table extends WP_List_Table {
 	 * @global object $tgmpa
 	 */
 	public function __construct() {
-	
+
 		global $status, $page, $_tgmpa;
-		
+
 		$object = new ReflectionProperty( 'TGM_Plugin_Activation', 'instance' ); // Store TGMPA static $instance in an object
-		
+
 		$_tgmpa = $object->getValue(); // Get the value of the instance
-		
-		parent::__construct( array(
-			'singular' 	=> 'plugin',
-			'plural' 	=> 'plugins',
-			'ajax' 		=> false
-		) );
-	
+
+		parent::__construct(
+			array(
+				'singular' 	=> 'plugin',
+				'plural' 	=> 'plugins',
+				'ajax' 		=> false,
+			)
+		);
+
 	}
-	
+
 	/**
-	 * Gathers and renames all of our plugin information to be used by 
+	 * Gathers and renames all of our plugin information to be used by
 	 * WP_List_Table to create our table.
 	 *
 	 * @since 2.2.0
 	 *
 	 */
 	protected function _gather_plugin_data() {
-	
+
 		global $_tgmpa;
-		
+
 		$table_data = array();
-		
+
 		$i = 0;
-		
+
 		$installed_plugins = get_plugins();
-		
+
 		$_tgmpa->admin_init();
-		
+
 		$_tgmpa->thickbox();
-		
+
 		foreach ( $_tgmpa->plugins as $plugin ) {
-		
 			if ( is_plugin_active( $plugin['file_path'] ) )
 				continue; // No need to display plugins if they are installed and activated
-		
+
 			$table_data[$i]['sanitized_plugin'] = $plugin['name'];
-			
+
 			$table_data[$i]['slug'] = $this->_get_plugin_data_from_name( $plugin['name'] );
-		
+
 			$source = $this->_get_plugin_data_from_name( $plugin['name'], 'source' );
 			if ( ! $source || preg_match( '|^http://wordpress.org/extend/plugins/|', $source ) ) {
-
-				$url = add_query_arg( array(
-					'tab'       => 'plugin-information',
-					'plugin'    => $this->_get_plugin_data_from_name( $plugin['name'] ),
-					'TB_iframe' => 'true',
-					'width'     => '640',
-					'height'    => '500',
-				), admin_url( 'plugin-install.php' ) );
+				$url = add_query_arg(
+					array(
+						'tab'       => 'plugin-information',
+						'plugin'    => $this->_get_plugin_data_from_name( $plugin['name'] ),
+						'tb_iframe' => 'true',
+						'width'     => '640',
+						'height'    => '500',
+					),
+					admin_url( 'plugin-install.php' )
+				);
 
 				$table_data[$i]['plugin'] = '<strong><a href="' . $url . '" class="thickbox" title="' . $plugin['name'] . '">' . $plugin['name'] . '</a></strong>';
-
 			}
 			else {
 				$table_data[$i]['plugin'] = '<strong>' . $plugin['name'] . '</strong>'; // No hyperlink
@@ -907,31 +876,30 @@ class TGMPA_List_Table extends WP_List_Table {
 
 			if ( isset( $table_data[$i]['plugin'] ) && (array) $table_data[$i]['plugin'] )
 				$plugin['name'] = $table_data[$i]['plugin'];
-				
+
 			$table_data[$i]['source'] = isset( $plugin['source'] ) ? __( 'Pre-Packaged', $_tgmpa->domain ) : __( 'Repository', $_tgmpa->domain );
-			
+
 			$table_data[$i]['type'] = $plugin['required'] ? __( 'Required', $_tgmpa->domain ) : __( 'Recommended', $_tgmpa->domain );
-			
+
 			if ( is_plugin_active( $plugin['file_path'] ) )
 				$table_data[$i]['status'] = sprintf( '<span style="background: #ebffe8;">%1$s</span>', __( 'Installed / Activated', $_tgmpa->domain ) );
-				
+
 			if ( ! isset( $installed_plugins[$plugin['file_path']] ) )
 				$table_data[$i]['status'] = sprintf( '<span style="background: #ffebe8;">%1$s</span>', __( 'Not Installed / Not Activated', $_tgmpa->domain ) );
 			elseif ( is_plugin_inactive( $plugin['file_path'] ) )
 				$table_data[$i]['status'] = sprintf( '<span style="background: #ffffe0;">%1$s</span>', __( 'Installed / Not Activated', $_tgmpa->domain ) );
-				
+
 			$table_data[$i]['file_path'] = $plugin['file_path'];
-			
+
 			$table_data[$i]['url'] = isset( $plugin['source'] ) ? $plugin['source'] : 'repo';
-					
+
 			$i++;
-			
 		}
-			
+
 		return $table_data;
-		
+
 	}
-	
+
 	/**
 	 * Retrieve plugin data, given the plugin name. Taken from the
 	 * TGM_Plugin_Activation class.
@@ -946,7 +914,7 @@ class TGMPA_List_Table extends WP_List_Table {
 	 * @return string|boolean Plugin slug if found, false otherwise.
 	 */
 	protected function _get_plugin_data_from_name( $name, $data = 'slug' ) {
-	
+
 		global $_tgmpa;
 
 		foreach ( $_tgmpa->plugins as $plugin => $values ) {
@@ -957,7 +925,7 @@ class TGMPA_List_Table extends WP_List_Table {
 		return false;
 
 	}
-	
+
 	/**
 	 * Create default columns to display important plugin information
 	 * like type, action and status.
@@ -968,21 +936,19 @@ class TGMPA_List_Table extends WP_List_Table {
 	 * @param string $column_name
 	 */
 	public function column_default( $item, $column_name ) {
-	
-		switch( $column_name ) {
-		
-			case 'source' :
-			case 'type' :
-			case 'status' :
+
+		switch ( $column_name ) {
+			case 'source':
+			case 'type':
+			case 'status':
 				return $item[$column_name];
-			
-			default :
+
+			default:
 				return print_r( $item, true );
-		
 		}
-	
+
 	}
-	
+
 	/**
 	 * Create default title column along with action links of 'Install'
 	 * and 'Activate'.
@@ -992,14 +958,14 @@ class TGMPA_List_Table extends WP_List_Table {
 	 * @param array $item
 	 */
 	public function column_plugin( $item ) {
-	
+
 		global $_tgmpa;
-		
+
 		$installed_plugins = get_plugins();
-		
+
 		if ( is_plugin_active( $item['file_path'] ) )
 			$actions = array();
-				
+
 		if ( ! isset( $installed_plugins[$item['file_path']] ) )
 			$actions = array(
 				'install' => sprintf( '<a href="%1$s" title="Install %2$s">Install</a>', wp_nonce_url( add_query_arg( array( 'page' => $_tgmpa->menu, 'plugin' => $item['slug'], 'plugin_name' => $item['sanitized_plugin'], 'plugin_source' => $item['url'], 'tgmpa-install' => 'install-plugin' ), admin_url( 'themes.php' ) ), 'tgmpa-install' ), $item['sanitized_plugin'] )
@@ -1008,11 +974,11 @@ class TGMPA_List_Table extends WP_List_Table {
 			$actions = array(
 				'activate' => sprintf( '<a href="%1$s" title="Activate %2$s">Activate</a>', wp_nonce_url( add_query_arg( array( 'page' => $_tgmpa->menu, 'plugin' => $item['slug'], 'plugin_name' => $item['sanitized_plugin'], 'plugin_source' => $item['url'], 'tgmpa-activate' => 'activate-plugin' ), admin_url( 'themes.php' ) ), 'tgmpa-activate' ), $item['sanitized_plugin'] )
 			);
-			
+
 		return sprintf( '%1$s %2$s', $item['plugin'], $this->row_actions( $actions ) );
-	
+
 	}
-	
+
 	/**
 	 * Required for bulk installing.
 	 *
@@ -1023,20 +989,20 @@ class TGMPA_List_Table extends WP_List_Table {
 	 * @param array $item
 	 */
 	public function column_cb( $item ) {
-	
+
 		return sprintf( '<input type="checkbox" name="%1$s[]" value="%2$s" id="%3$s" />', $this->_args['singular'], $item['file_path'] . ',' . $item['url'] . ',' . $item['sanitized_plugin'], $item['sanitized_plugin'] );
-	
+
 	}
-	
+
 	/**
 	 * Output all the column information within the table.
 	 *
 	 * @since 2.2.0
 	 */
 	public function get_columns() {
-	
+
 		global $_tgmpa;
-	
+
 		$columns = array(
 			'cb' 		=> '<input type="checkbox" />',
 			'plugin' 	=> __( 'Plugin', $_tgmpa->domain ),
@@ -1044,11 +1010,11 @@ class TGMPA_List_Table extends WP_List_Table {
 			'type' 		=> __( 'Type', $_tgmpa->domain ),
 			'status' 	=> __( 'Status', $_tgmpa->domain )
 		);
-		
+
 		return $columns;
-	
+
 	}
-	
+
 	/**
 	 * Defines all types of bulk actions for handling
 	 * registered plugins.
@@ -1056,49 +1022,46 @@ class TGMPA_List_Table extends WP_List_Table {
 	 * @since 2.2.0
 	 */
 	public function get_bulk_actions() {
-	
+
 		global $_tgmpa;
-	
+
 		$actions = array(
 			'tgmpa-bulk-install' 	=> __( 'Install', $_tgmpa->domain ),
 			'tgmpa-bulk-activate' 	=> __( 'Activate', $_tgmpa->domain ),
 		);
-		
+
 		return $actions;
-	
+
 	}
-	
+
 	/**
 	 * Processes bulk installation and activation actions.
 	 *
 	 * @since 2.2.0
 	 */
 	protected function _process_bulk_actions() {
-	
+
 		global $_tgmpa;
-	
+
 		if ( 'tgmpa-bulk-install' === $this->current_action() ) {
-		
 			check_admin_referer( 'bulk-' . $this->_args['plural'] );
-			
+
 			$plugins = isset( $_POST[sanitize_key( 'plugin' )] ) ? (array) $_POST[sanitize_key( 'plugin' )] : array();
 			$plugins_to_install = array();
-			
+
 			/** Split plugin value into array with plugin file path, plugin source and plugin name */
 			foreach ( $plugins as $i => $plugin )
 				$plugins_to_install[] = explode( ',', $plugin );
-				
+
 			foreach ( $plugins_to_install as $i => $array ) {
-			
 				if ( preg_match( '|.php$|', $array[0] ) ) // Plugins that haven't been installed yet won't have the correct file path
 					unset( $plugins_to_install[$i] );
-					
 			}
-			
+
 			/** If our check removes all plugins from the array, do nothing */
 			if ( empty( $plugins_to_install ) )
 				return;
-				
+
 			$method = ''; // Leave blank so WP_Filesystem can populate it as necessary
 
 			$url = wp_nonce_url( 'themes.php?page=' . $_tgmpa->menu, 'tgmpa-install' ); // Make sure we are coming from the right page
@@ -1106,48 +1069,45 @@ class TGMPA_List_Table extends WP_List_Table {
 				return true;
 
 			if ( ! WP_Filesystem( $creds ) ) {
-
 				request_filesystem_credentials( $url, $method, true, false ); // Setup WP_Filesystem
 				return true;
-
 			}
-			
+
 			require_once ABSPATH . 'wp-admin/includes/plugin-install.php'; // Need for plugins_api
 			require_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php'; // Need for upgrade classes
-			
-			$api = array(); // Store plugins_api object information in an array
+
+			$api    = array(); // Store plugins_api object information in an array
 			$source = array();
-			
+
 			foreach ( $plugins_to_install as $plugin )
 				$api[] = plugins_api( 'plugin_information', array( 'slug' => $plugin[0], 'fields' => array( 'sections' => false ) ) );
-				
+
 			if ( is_wp_error( $api ) )
 				wp_die( $_tgmpa->strings['oops'] . var_dump( $api ) );
-			
-			foreach ( $api as $object )		
+
+			foreach ( $api as $object )
 				$source[] = isset( $object->download_link ) ? $object->download_link : '';
-				
+
 			$i = 0;
-				
+
 			foreach ( $plugins_to_install as $plugin ) {
-			
 				// Prep variables for Plugin_Installer_Skin class
 				$title = sprintf( $_tgmpa->strings['installing'], $plugin[2] );
 				$nonce = 'install-plugin_' . $plugin[0];
-				$url = add_query_arg( array( 'action' => 'install-plugin', 'plugin' => $plugin[0] ), 'update.php' );
+				$url   = add_query_arg( array( 'action' => 'install-plugin', 'plugin' => $plugin[0] ), 'update.php' );
 				if ( isset( $_GET['from'] ) )
 					$url .= add_query_arg( 'from', urlencode( stripslashes( $_GET['from'] ) ), $url );
-				
+
 				if ( isset( $plugin[1] ) && 'repo' == $plugin[1] && isset( $source[$i] ) )
 					$plugin[1] = $source[$i];
-					
+
 				/** Set type, based on whether the source starts with http:// or https:// */
-				$type = preg_match('|^http(s)?://|', $plugin[1] ) ? 'web' : 'upload';
+				$type = preg_match( '|^http(s)?://|', $plugin[1] ) ? 'web' : 'upload';
 
 				/** Prefix a default path to pre-packaged plugins */
 				$install_package = ( 'upload' == $type ) ? $_tgmpa->default_path . $plugin[1] : $plugin[1];
-				
-				$upgrader = new Plugin_Upgrader( new Plugin_Installer_Skin( compact( 'title', 'url', 'nonce', 'plugin' ), 'api' ) ); // Create a new instance of Plugin_Upgrader
+
+				$upgrader = new Plugin_Upgrader( $skin = new Plugin_Installer_Skin( compact( 'title', 'url', 'nonce', 'plugin' ), 'api' ) ); // Create a new instance of Plugin_Upgrader
 
 				$upgrader->install( $install_package ); // Perform the action and install the plugin from the $source urldecode()
 
@@ -1158,7 +1118,7 @@ class TGMPA_List_Table extends WP_List_Table {
 				$activate = activate_plugin( $plugin_activate ); // Activate the plugin
 
 				$_tgmpa->populate_file_path(); // Re-populate the file path now that the plugin has been installed and activated
-				
+
 				$i++;
 
 				if ( is_wp_error( $activate ) ) {
@@ -1169,85 +1129,78 @@ class TGMPA_List_Table extends WP_List_Table {
 				else {
 					echo '<p>' . $_tgmpa->strings['plugin_activated'] . '</p>';
 				}
-				
 			}
-		
 		}
-			
+
 		if ( 'tgmpa-bulk-activate' === $this->current_action() ) {
-		
 			check_admin_referer( 'bulk-' . $this->_args['plural'] );
-			
+
 			$plugins = isset( $_POST[sanitize_key( 'plugin' )] ) ? (array) $_POST[sanitize_key( 'plugin' )] : array();
 			$plugins_to_activate = array();
-			
+
 			/** Split plugin value into array with plugin file path, plugin source and plugin name */
 			foreach ( $plugins as $i => $plugin )
 				$plugins_to_activate[] = explode( ',', $plugin );
-				
+
 			foreach ( $plugins_to_activate as $i => $array ) {
-			
 				if ( ! preg_match( '|.php$|', $array[0] ) ) // Plugins that haven't been installed yet won't have the correct file path
 					unset( $plugins_to_activate[$i] );
-					
 			}
-			
+
 			if ( empty( $plugins_to_activate ) )
 				return;
-				
+
 			$plugins = array();
 			$plugin_names = array();
-				
+
 			foreach ( $plugins_to_activate as $plugin_string ) {
 				$plugins[] = $plugin_string[0];
 				$plugin_names[] = $plugin_string[2];
 			}
-			
+
 			$last_plugin = array_pop( $plugin_names ); // Pop off last name to prep for readability
-			$imploded = empty( $plugin_names ) ? '<strong>' . $last_plugin . '</strong>' : '<strong>' . ( implode( ', ', $plugin_names ) . '</strong> and <strong>' . $last_plugin . '</strong>.' );
-				
+			$imploded    = empty( $plugin_names ) ? '<strong>' . $last_plugin . '</strong>' : '<strong>' . ( implode( ', ', $plugin_names ) . '</strong> and <strong>' . $last_plugin . '</strong>.' );
+
 			/** Now we are good to go - let's start activating plugins */
 			$activate = activate_plugins( $plugins );
-			
+
 			if ( is_wp_error( $activate ) )
 				echo '<div id="message" class="error"><p>' . $activate->get_error_message() . '</p></div>';
 			else
 				printf( '<div id="message" class="updated"><p>%1$s %2$s</p></div>', __( 'The following plugins were successfully activated:', $_tgmpa->domain ), $imploded );
- 			
+
  			/** Update recently activated plugins option */
 			$recent = (array) get_option( 'recently_activated' );
-			
+
 			foreach ( $plugins as $plugin => $time )
 				if ( isset( $recent[$plugin] ) )
 					unset( $recent[$plugin] );
 
 			update_option( 'recently_activated', $recent );
-		
 		}
-	
 	}
-	
+
 	/**
 	 * Prepares all of our information to be outputted into a usable table.
 	 *
 	 * @since 2.2.0
 	 */
 	public function prepare_items() {
-	
+
 		$per_page = 100; // Set it high so we shouldn't have to worry about pagination
-	
+
 		$columns = $this->get_columns();
-		
+
 		$hidden = array(); // No columns to hide, but we must set as an array
-		
+
 		$sortable = array(); // No reason to make sortable columns
-		
+
 		$this->_column_headers = array( $columns, $hidden, $sortable );
-		
+
 		$this->_process_bulk_actions();
-		
+
 		$this->items = $this->_gather_plugin_data(); // Grab all of our plugin information
-	
+
 	}
 
 }

--- a/tgm-plugin-activation/example.php
+++ b/tgm-plugin-activation/example.php
@@ -8,7 +8,7 @@
  *
  * @package	   TGM-Plugin-Activation
  * @subpackage Example
- * @version	   2.1.1
+ * @version	   2.2.0
  * @author	   Thomas Griffin <thomas@thomasgriffinmedia.com>
  * @author	   Gary Jones <gamajo@gamajo.com>
  * @copyright  Copyright (c) 2011, Thomas Griffin
@@ -41,53 +41,53 @@ function my_theme_register_required_plugins() {
 	 * If the source is NOT from the .org repo, then source is also required.
 	 */
 	$plugins = array(
-		/** This is an example of how to include a plugin pre-packaged with a theme */
+
+		// This is an example of how to include a plugin pre-packaged with a theme
 		array(
 			'name'     => 'TGM Example Plugin', // The plugin name
 			'slug'     => 'tgm-example-plugin', // The plugin slug (typically the folder name)
 			'source'   => get_stylesheet_directory() . '/lib/plugins/tgm-example-plugin.zip', // The plugin source
-			'required' => true // If false, the plugin is only 'recommended' instead of required
+			'required' => true, // If false, the plugin is only 'recommended' instead of required
 		),
-		/** This is an example of how to include a plugin from the WordPress Plugin Repository */
+
+		// This is an example of how to include a plugin from the WordPress Plugin Repository
 		array(
 			'name' => 'BuddyPress',
 			'slug' => 'buddypress',
-			'required' => false
-		)
+			'required' => false,
+		),
+
 	);
 
-	/** Change this to your theme text domain, used for internationalising strings */
+	// Change this to your theme text domain, used for internationalising strings
 	$theme_text_domain = 'tgmpa';
 
 	/**
-	 * Array of configuration settings. Uncomment and amend each line as needed.
+	 * Array of configuration settings. Amend each line as needed.
 	 * If you want the default strings to be available under your own theme domain,
-	 * uncomment the strings and domain.
+	 * leave the strings uncommented.
 	 * Some of the strings are added into a sprintf, so see the comments at the
 	 * end of each line for what each argument will be.
 	 */
 	$config = array(
-		/*'domain'       => $theme_text_domain,         // Text domain - likely want to be the same as your theme. */
-		/*'default_path' => '',                         // Default absolute path to pre-packaged plugins */
-		/*'menu'         => 'install-required-plugins', // Menu slug */
-		/*'notices'      => true,                       // Show admin notices or not */
+		'domain'       => $theme_text_domain,         // Text domain - likely want to be the same as your theme.
+		'default_path' => '',                         // Default absolute path to pre-packaged plugins
+		'menu'         => 'install-required-plugins', // Menu slug
+		'notices'      => true,                       // Show admin notices or not
 		'strings'      => array(
-			/*'page_title'             				=> __( 'Install Required Plugins', $theme_text_domain ), // */
-			/*'menu_title'             				=> __( 'Install Plugins', $theme_text_domain ), // */
-			/*'instructions_install'   				=> __( 'The %1$s plugin is required for this theme. Click on the big blue button below to install and activate %1$s.', $theme_text_domain ), // %1$s = plugin name */
-			/*'instructions_install_recommended'	=> __( 'The %1$s plugin is recommended for this theme. Click on the big blue button below to install and activate %1$s.', $theme_text_domain ), // %1$s = plugin name, %2$s = plugins page URL */
-			/*'instructions_activate'  				=> __( 'The %1$s plugin is installed but currently inactive. Please go to the <a href="%2$s">plugin administration page</a> page to activate it.', $theme_text_domain ), // %1$s = plugin name, %2$s = plugins page URL */
-			/*'button'                 				=> __( 'Install %s Now', $theme_text_domain ), // %1$s = plugin name */
-			/*'installing'             				=> __( 'Installing Plugin: %s', $theme_text_domain ), // %1$s = plugin name */
-			/*'oops'                   				=> __( 'Something went wrong with the plugin API.', $theme_text_domain ), // */
-			/*'notice_can_install_required'     	=> __( 'This theme requires the following plugins: %1$s.', $theme_text_domain ), // %1$s = plugin names */
-			/*'notice_can_install_recommended'		=> __( 'This theme recommends the following plugins: %1$s.', $theme_text_domain ), // %1$s = plugin names */
-			/*'notice_cannot_install'  				=> __( 'Sorry, but you do not have the correct permissions to install the %s plugin. Contact the administrator of this site for help on getting the plugin installed.', $theme_text_domain ), // %1$s = plugin name */
-			/*'notice_can_activate_required'    	=> __( 'The following required plugins are currently inactive: %1$s.', $theme_text_domain ), // %1$s = plugin names */
-			/*'notice_can_activate_recommended'		=> __( 'The following recommended plugins are currently inactive: %1$s.', $theme_text_domain ), // %1$s = plugin names */
-			/*'notice_cannot_activate' 				=> __( 'Sorry, but you do not have the correct permissions to activate the %s plugin. Contact the administrator of this site for help on getting the plugin activated.', $theme_text_domain ), // %1$s = plugin name */
-			/*'return'                 				=> __( 'Return to Required Plugins Installer', $theme_text_domain ), // */
-			/*'plugin_activated' 	   				=> __( 'Plugin activated successfully.', $theme_text_domain ) // */
+			'page_title'                       => __( 'Install Required Plugins', $theme_text_domain ),
+			'menu_title'                       => __( 'Install Plugins', $theme_text_domain ),
+			'button'                           => __( 'Install %s Now', $theme_text_domain ), // %1$s = plugin name
+			'installing'                       => __( 'Installing Plugin: %s', $theme_text_domain ), // %1$s = plugin name
+			'oops'                             => __( 'Something went wrong with the plugin API.', $theme_text_domain ),
+			'notice_can_install_required'      => __( 'This theme requires the following plugins: %1$s.', $theme_text_domain ), // %1$s = plugin names
+			'notice_can_install_recommended'   => __( 'This theme recommends the following plugins: %1$s.', $theme_text_domain ), // %1$s = plugin names
+			'notice_cannot_install'            => __( 'Sorry, but you do not have the correct permissions to install the %s plugin. Contact the administrator of this site for help on getting the plugin installed.', $theme_text_domain ), // %1$s = plugin name
+			'notice_can_activate_required'     => __( 'The following required plugins are currently inactive: %1$s.', $theme_text_domain ), // %1$s = plugin names
+			'notice_can_activate_recommended'  => __( 'The following recommended plugins are currently inactive: %1$s.', $theme_text_domain ), // %1$s = plugin names
+			'notice_cannot_activate'           => __( 'Sorry, but you do not have the correct permissions to activate the %s plugin. Contact the administrator of this site for help on getting the plugin activated.', $theme_text_domain ), // %1$s = plugin name
+			'return'                           => __( 'Return to Required Plugins Installer', $theme_text_domain ),
+			'plugin_activated'                 => __( 'Plugin activated successfully.', $theme_text_domain ),
 		)
 	);
 


### PR DESCRIPTION
Having run PHP_CodeSniffer with the WordPress CS (falls back to using PEAR standards when WP CS isn't explicit) on the code, I found 112 errors. Most fall under the control structures category - including a blank line within the start or end of { } for if, foreach, etc.
This commit addresses all but 1 error, and this is where we don't assign the `new TGM_Plugin_Activation;! instantiation to a (global) variable, which I'm fine with at least for now.
