### PR TITLE
TGM-Plugin-Activation - Multisite Installs can download from WordPress Plugin Directory

### DIFF
--- a/tgm-plugin-activation/class-tgm-plugin-activation.php
+++ b/tgm-plugin-activation/class-tgm-plugin-activation.php
@@ -203,7 +203,10 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
                         if ( is_multisite() ) //Determine if Multisite support is enabled.
 
                              /** multisite supported, so grab the path to the plugin-install.php from the network folder*/
-                             $this->plugin_install_file = admin_url( 'network/plugin-install.php' );
+                             /*uses network_admin_url() to pull the url of the base blog, because multisite plugins can only be installed from the base blog. */
+
+                             
+                             $this->plugin_install_file = network_admin_url('plugin-install.php' );
 
                         else /** multisite is not supported so use the regular plugin-install.php file*/
                              $this->plugin_install_file = admin_url( 'plugin-install.php' );


### PR DESCRIPTION
 Added additional support for multisite. Allows installation of wordpress plugins from the WordPress Plugin Directory
## Made changes because I could not install wordpress plugins from the WordPress Plugin Directory.

when using wordpress version 3.4.2 with multisite installed
the plugins listed did not correctly point to the WordPress Plugin Directory.

The problem was with the actual location of the plugin-install.php.

single site install of wordpress uses:
wp-admin/plugin-install.php 

multisite uses
wp-admin/network/plugin-install.php 
## Added the code

if ( is_multisite() ) {
     $this->plugin_install_file = admin_url( 'network/plugin-install.php' );}

else{
     $this->plugin_install_file = admin_url( 'plugin-install.php' ); }

-----replaced  code------------------------

replaced:  admin_url( 'plugin-install.php' )
with:      $this->plugin_install_file
