### PR TITLE
Strict Error in TGM_Bulk_Installer_Skin class on update to WP3.6

### DIFF
--- a/tgm-plugin-activation/class-tgm-plugin-activation.php
+++ b/tgm-plugin-activation/class-tgm-plugin-activation.php
@@ -1968,7 +1968,7 @@ if ( ! class_exists( 'WP_Upgrader' ) && ( isset( $_GET[sanitize_key( 'page' )] )
 	 		 *
 	 		 * @since 2.2.0
 	 		 */
-			public function before() {
+			public function before( $title='' ) {
 
 				/** We are currently in the plugin installation loop, so set to true */
 				$this->in_loop = true;
@@ -1990,7 +1990,7 @@ if ( ! class_exists( 'WP_Upgrader' ) && ( isset( $_GET[sanitize_key( 'page' )] )
 	 		 *
 	 		 * @since 2.2.0
 	 		 */
-			public function after() {
+			public function after( $title='' ) {
 
 				/** Close install strings */
 				echo '</p></div>';


### PR DESCRIPTION
TGM_Bulk_Installer_Skin::before() should be compatible with WP_Upgrader_Skin::before()
TGM_Bulk_Installer_Skin::after() should be compatible with WP_Upgrader_Skin::after()

added in default variable to methods
