### PR TITLE
Use add_theme_page to display the menu rather than add_submenu_page

### DIFF
--- a/tgm-plugin-activation/class-tgm-plugin-activation.php
+++ b/tgm-plugin-activation/class-tgm-plugin-activation.php
@@ -326,8 +326,7 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
 
 			foreach ( $this->plugins as $plugin ) {
 				if ( ! is_plugin_active( $plugin['file_path'] ) ) {
-					add_submenu_page(
-						$this->parent_menu_slug,				// Parent menu slug
+					add_theme_page(
 						$this->strings['page_title'],           // Page title
 						$this->strings['menu_title'],           // Menu title
 						'edit_theme_options',                   // Capability


### PR DESCRIPTION
`add_submenu_page` causing a warning in theme-check plugin. Reference: http://codex.wordpress.org/Function_Reference/add_theme_page
