### PR TITLE
Don't rely on version numbers and avoid notices

### DIFF
--- a/tgm-plugin-activation/class-tgm-plugin-activation.php
+++ b/tgm-plugin-activation/class-tgm-plugin-activation.php
@@ -585,22 +585,16 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
 				/** If the plugin is installed and active, check for minimum version argument before moving forward */
 				if ( is_plugin_active( $plugin['file_path'] ) ) {
 					/** A minimum version has been specified */
-					if ( isset( $plugin['version'] ) ) {
-						if ( isset( $installed_plugins[$plugin['file_path']]['Version'] ) ) {
-							/** If the current version is less than the minimum required version, we display a message */
-							if ( version_compare( $installed_plugins[$plugin['file_path']]['Version'], $plugin['version'], '<' ) ) {
-								if ( current_user_can( 'install_plugins' ) )
-									$message['notice_ask_to_update'][] = $plugin['name'];
-								else
-									$message['notice_cannot_update'][] = $plugin['name'];
-							}
-						}
-						/** Can't find the plugin, so iterate to the next condition */
-						else {
-							continue;
+					if ( isset( $installed_plugins[$plugin['file_path']]['Version'] ) ) {
+						/** If the current version is less than the minimum required version, we display a message */
+						if ( version_compare( $installed_plugins[$plugin['file_path']]['Version'], $plugin['version'], '<' ) ) {
+							if ( current_user_can( 'install_plugins' ) )
+								$message['notice_ask_to_update'][] = $plugin['name'];
+							else
+								$message['notice_cannot_update'][] = $plugin['name'];
 						}
 					}
-					/** No minimum version specified, so iterate over the plugin */
+					/** Can't find the plugin, so iterate to the next condition */
 					else {
 						continue;
 					}


### PR DESCRIPTION
I've noticed that your documentation warns that notice is thrown if the version number is not specified - http://tgmpluginactivation.com/#installation

I see two issues with that:
1. Theme authors don't specify version numbers which leads to broken themes for the end user, messing with the error log and generally something that is not expected to happen for the plugin.
2. Version number isn't always needed, if the plugin is updated often and the theme is compatible with all future updates.

My proposal is removing the check for version number and setting 0.0 (or some other number if needed) as a min version, the plugin seems to handle that gracefully. Any thoughts on that?
