### PR TITLE
Comply with before/after methods from Bulk Upgrader class

### DIFF
--- a/tgm-plugin-activation/class-tgm-plugin-activation.php
+++ b/tgm-plugin-activation/class-tgm-plugin-activation.php
@@ -1974,7 +1974,7 @@ if ( ! class_exists( 'WP_Upgrader' ) && ( isset( $_GET[sanitize_key( 'page' )] )
 	 		 *
 	 		 * @since 2.2.0
 	 		 */
-			public function before() {
+			public function before( $title = '' ) {
 
 				/** We are currently in the plugin installation loop, so set to true */
 				$this->in_loop = true;
@@ -1996,7 +1996,7 @@ if ( ! class_exists( 'WP_Upgrader' ) && ( isset( $_GET[sanitize_key( 'page' )] )
 	 		 *
 	 		 * @since 2.2.0
 	 		 */
-			public function after() {
+			public function after( $title = '' ) {
 
 				/** Close install strings */
 				echo '</p></div>';


### PR DESCRIPTION
As per [#135](https://github.com/thomasgriffin/TGM-Plugin-Activation/issues/135) the Bulk Upgrader class required an optional title in before/after functions, adding for compliance. 
