### PR TITLE
_get_plugin_basename_from_slug should check for a '/'

### DIFF
--- a/tgm-plugin-activation/class-tgm-plugin-activation.php
+++ b/tgm-plugin-activation/class-tgm-plugin-activation.php
@@ -824,7 +824,7 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
 			$keys = array_keys( get_plugins() );
 
 			foreach ( $keys as $key ) {
-				if ( preg_match( '|^' . $slug .'|', $key ) )
+				if ( preg_match( '|^' . $slug .'/|', $key ) )
 					return $key;
 			}
 


### PR DESCRIPTION
This addresses #147 (https://github.com/thomasgriffin/TGM-Plugin-Activation/issues/147)
