### PR TITLE
change add_submenu_page to add_theme_page

### DIFF
--- a/tgm-plugin-activation/class-tgm-plugin-activation.php
+++ b/tgm-plugin-activation/class-tgm-plugin-activation.php
@@ -326,7 +326,7 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
 
 			foreach ( $this->plugins as $plugin ) {
 				if ( ! is_plugin_active( $plugin['file_path'] ) ) {
-					add_submenu_page(
+					add_theme_page(
 						$this->parent_menu_slug,				// Parent menu slug
 						$this->strings['page_title'],           // Page title
 						$this->strings['menu_title'],           // Menu title


### PR DESCRIPTION
According to the Theme Check plugin, you are required to use add_theme_page for adding admin pages rather than add_submenu_page. Tested and seems to works fine - great work, thanks!
