### PR TITLE
Add filters to enable more customization

### DIFF
--- a/class-tgm-plugin-activation.php
+++ b/class-tgm-plugin-activation.php
@@ -352,16 +352,19 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
             foreach ( $this->plugins as $plugin ) {
                 if ( ! is_plugin_active( $plugin['file_path'] ) ) {
 
-                    $args = apply_filters('tgmpa_admin_menu_args', array(
-                        'parent_slug'=> 'themes.php',                          // Parent Menu slug.
-                        'page_title' => $this->strings['page_title'],          // Page title.
-                        'menu_title' => $this->strings['menu_title'],          // Menu title.
-                        'capability' => 'edit_theme_options',                  // Capability.
-                        'menu_slug'  => $this->menu,                           // Menu slug.
-                        'function'   => array( $this, 'install_plugins_page' ) // Callback.
-                    ));
+                    $args = apply_filters(
+                    	'tgmpa_admin_menu_args',
+                    	array(
+	                        'parent_slug'=> 'themes.php',                          // Parent Menu slug.
+	                        'page_title' => $this->strings['page_title'],          // Page title.
+	                        'menu_title' => $this->strings['menu_title'],          // Menu title.
+	                        'capability' => 'edit_theme_options',                  // Capability.
+	                        'menu_slug'  => $this->menu,                           // Menu slug.
+	                        'function'   => array( $this, 'install_plugins_page' ) // Callback.
+	                    )
+					);
 
-                    if(apply_filters( 'tgmpa_admin_menu_use_add_theme_page', true )) {
+                    if( apply_filters( 'tgmpa_admin_menu_use_add_theme_page', true ) ) {
                         add_theme_page($args['page_title'], $args['menu_title'], $args['capability'], $args['menu_slug'], $args['function']);
                     } else {
                         add_submenu_page( $args['parent_slug'], $args['page_title'], $args['menu_title'], $args['capability'], $args['menu_slug'], $args['function']);
@@ -625,7 +628,7 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
 
             foreach ( $this->plugins as $plugin ) {
                 // If the plugin is installed and active, check for minimum version argument before moving forward.
-                if ( is_plugin_active( $plugin['file_path'] ) ) {
+                if ( is_plugin_active( $plugin['file_path'] ) || ( isset( $plugin['is_callable'] ) && is_callable( $plugin['is_callable'] ) ) ) {
                     // A minimum version has been specified.
                     if ( isset( $plugin['version'] ) ) {
                         if ( isset( $installed_plugins[$plugin['file_path']]['Version'] ) ) {
@@ -757,7 +760,7 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
 
                 $action_links = array_filter( $action_links ); // Remove any empty array items.
                 if ( $action_links ) {
-                    $rendered .= apply_filters('tgmpa_notice_rendered_action_links', '<p>' . implode( ' | ', $action_links ) . '</p>');
+                    $rendered .= apply_filters( 'tgmpa_notice_rendered_action_links', '<p>' . implode( ' | ', $action_links ) . '</p>' );
                 }
 
                 // Register the nag messages and prepare them to be processed.
@@ -1142,7 +1145,7 @@ if ( ! class_exists( 'TGMPA_List_Table' ) ) {
             $installed_plugins = get_plugins();
 
             foreach ( TGM_Plugin_Activation::$instance->plugins as $plugin ) {
-                if ( is_plugin_active( $plugin['file_path'] ) ) {
+                if ( is_plugin_active( $plugin['file_path'] ) || ( isset( $plugin['is_callable'] ) && is_callable( $plugin['is_callable'] ) ) ) {
                     continue; // No need to display plugins if they are installed and activated.
                 }
 


### PR DESCRIPTION
- Added `tgmpa_submenu_parent_slug` filter - modify what menu the sub-page is under, instead of requiring it under "Appearance". This allows the page to be added to a plugin's sub-menu.
- Added `tgmpa_table_columns` filter - modify table columns in table view
- Added `tgmpa_table_data_item` filter - modify plugin data that's ready for the table output
- Added `tgmpa_notice_rendered_action_links` filter - modify final action link output

I wanted to add a "Description" column that says why should an user install this plugin.

```
array(
    'name'      => 'WordPress SEO by Yoast',
    'slug'      => 'wordpress-seo',
    'description' => 'This is a valuable SEO plugin.',
);
```

These filters allow much more flexibility in the setup.
