### PR TITLE
Allow adding a plugin parameter named `is_callable`

### DIFF
--- a/class-tgm-plugin-activation.php
+++ b/class-tgm-plugin-activation.php
@@ -616,7 +616,7 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
 
             foreach ( $this->plugins as $plugin ) {
                 // If the plugin is installed and active, check for minimum version argument before moving forward.
-                if ( is_plugin_active( $plugin['file_path'] ) || ( isset( $plugin['is_callable'] ) && is_callable( $plugin['is_callable'] ) ) ) {foreach ( TGM_Plugin_Activation::$instance->plugins as $plugin ) {
+                if ( is_plugin_active( $plugin['file_path'] ) || ( isset( $plugin['is_callable'] ) && is_callable( $plugin['is_callable'] ) ) ) {
                     // A minimum version has been specified.
                     if ( isset( $plugin['version'] ) ) {
                         if ( isset( $installed_plugins[$plugin['file_path']]['Version'] ) ) {


### PR DESCRIPTION
Here's a use case: Yoast's WordPress SEO Plugin and the Premium version. Mostly same plugin but different slugs. This allows you to say "no, the slug doesn't exist, but this function (or method) is callable, so the plugin must be active".

Here's the plugin array item passed to `tgmpa()`: 

```
array(
    'name'      => 'WordPress SEO by Yoast',
    'slug'      => 'wordpress-seo',
    'required'  => false,
    'is_callable' => 'wpseo_init',
)
```

If the `wpseo_init()` function exists, the WordPress SEO Premium plugin is still considered active, even the slug would normally be `wordpress-seo-premium`. This makes it possible to add some basic logic outside slug names.
