### PR TITLE
Remove the code that alters the `wp_admin_bar_render` hooks.

### DIFF
--- a/class-tgm-plugin-activation.php
+++ b/class-tgm-plugin-activation.php
@@ -233,14 +233,6 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
                 add_filter( 'install_plugin_complete_actions', array( $this, 'actions' ) );
                 add_action( 'switch_theme', array( $this, 'flush_plugins_cache' ) );
 
-                // Load admin bar in the header to remove flash when installing plugins.
-                if ( $this->is_tgmpa_page() ) {
-                    remove_action( 'wp_footer', 'wp_admin_bar_render', 1000 );
-                    remove_action( 'admin_footer', 'wp_admin_bar_render', 1000 );
-                    add_action( 'wp_head', 'wp_admin_bar_render', 1000 );
-                    add_action( 'admin_head', 'wp_admin_bar_render', 1000 );
-                }
-
                 if ( $this->has_notices ) {
                     add_action( 'admin_notices', array( $this, 'notices' ) );
                     add_action( 'admin_init', array( $this, 'admin_init' ), 1 );


### PR DESCRIPTION
The code that alters the hooks for the admin bar is redundant and causes the admin bar to be processed twice on the "Install Required Plugins" screen.

The following two lines are erroneous because `wp_admin_bar_render` hasn't been hooked to `admin_footer` since WordPress 3.4 ([Trac ticket #20161](https://core.trac.wordpress.org/ticket/20161)).

`remove_action( 'admin_footer', 'wp_admin_bar_render', 1000 );`
`add_action( 'admin_head', 'wp_admin_bar_render', 1000 );`

This causes `wp_admin_bar_render` to be hooked twice, once on the default `in_admin_header` and once on `admin_head`. The net effect is that the admin bar is processed twice, which causes breakage. An example of this in the wild is my [User Switching](https://wordpress.org/plugins/user-switching/) plugin which throws a notice on this screen due to the node it hooks onto not being available.

Additionally, the following two lines achieve nothing because we're in the admin area so they can be removed too:

`remove_action( 'wp_footer', 'wp_admin_bar_render', 1000 );`
`add_action( 'wp_head', 'wp_admin_bar_render', 1000 );`
