### PR TITLE
Notice no longer thrown when 'required' missing

### DIFF
--- a/class-tgm-plugin-activation.php
+++ b/class-tgm-plugin-activation.php
@@ -635,7 +635,8 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
                     $install_link = true; // We need to display the 'install' action link.
                     $install_link_count++; // Increment the install link count.
                     if ( current_user_can( 'install_plugins' ) ) {
-                        if ( $plugin['required'] ) {
+                        if ( array_key_exists('required', $plugin) ) {
+                        if ( isset($plugin['required']) ) {
                             $message['notice_can_install_required'][] = $plugin['name'];
                         }
                         // This plugin is only recommended.

--- a/class-tgm-plugin-activation.php
+++ b/class-tgm-plugin-activation.php
@@ -635,7 +635,6 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
                     $install_link = true; // We need to display the 'install' action link.
                     $install_link_count++; // Increment the install link count.
                     if ( current_user_can( 'install_plugins' ) ) {
-                        if ( array_key_exists('required', $plugin) ) {
                         if ( isset($plugin['required']) ) {
                             $message['notice_can_install_required'][] = $plugin['name'];
                         }


### PR DESCRIPTION
PHP Notice no longer thrown when plugin array's 'required' key is missing.