### PR TITLE
Default WP_List_Table Styles Rule for UI Improvement

### DIFF
--- a/class-tgm-plugin-activation.php
+++ b/class-tgm-plugin-activation.php
@@ -1115,7 +1115,6 @@ if ( ! class_exists( 'TGMPA_List_Table' ) ) {
             parent::__construct(
                 array(
                     'singular' => 'plugin',
-                    'plural'   => 'plugins',
                     'ajax'     => false,
                 )
             );


### PR DESCRIPTION
Since `TGMPA_List_Table` is hijacking and extending `WP_List_Table` which is private class and is Limited for core usage only. Similary, we are utilizing similar plural args of `WP_Plugins_List_Table`  too. Means we are adding plugins page style rules directly from the core plugins page and our table `<thead> and <tfoot>` checkbox are not well managed as well as other css stuffs. Thus let's be smart and accept default `WP_List_Table` styles rather than Plugins Page. 

``` php
/**
 * Confidential Information!
 * WP_Plugins_List_Table is already utilizing 'plural' => 'plugins'
 * Let's be smart dudes and use only singular args :)
 */
parent::__construct( array(
    'plural' => 'plugins',
    'screen' => isset( $args['screen'] ) ? $args['screen'] : null,
) );
```
