### PR TITLE
[Develop] Prevent duplicate message showing

### DIFF
--- a/class-tgm-plugin-activation.php
+++ b/class-tgm-plugin-activation.php
@@ -771,10 +771,26 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
 
             // Admin options pages already output settings_errors, so this is to avoid duplication.
             if ( 'options-general' !== $current_screen->parent_base ) {
-                settings_errors( 'tgmpa' );
+                $this->display_settings_errors();
             }
 
         }
+        
+        /**
+         * Display settings errors and remove those which have been displayed to avoid duplicate messages showing
+         */
+        private function display_settings_errors() {
+			global $wp_settings_errors;
+
+			settings_errors( 'tgmpa' );
+			
+			foreach ( (array) $wp_settings_errors as $key => $details ) {
+				if ( 'tgmpa' === $details['setting'] ) {
+					unset( $wp_settings_errors[ $key ] );
+					break;
+				}
+			}
+		}
 
         /**
          * Add dismissable admin notices.

--- a/class-tgm-plugin-activation.php
+++ b/class-tgm-plugin-activation.php
@@ -778,8 +778,10 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
         
         /**
          * Display settings errors and remove those which have been displayed to avoid duplicate messages showing
+         *
+         * @since 2.4.x
          */
-        private function display_settings_errors() {
+        protected function display_settings_errors() {
 			global $wp_settings_errors;
 
 			settings_errors( 'tgmpa' );


### PR DESCRIPTION
Quite a few themes and plugins which don't have their settings pages under 'options-general' also use `settings_errors()` to display their notices to the user.

This resulted in the TGMPA messages being shown twice on those pages as reported in #237.

This PR fixes that.

Related: https://core.trac.wordpress.org/ticket/31000