### PR TITLE
[Master] Bug fix: only the user which switched theme would be re-notified

### DIFF
--- a/class-tgm-plugin-activation.php
+++ b/class-tgm-plugin-activation.php
@@ -935,14 +935,14 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
         /**
          * Delete dismissable nag option when theme is switched.
          *
-         * This ensures that the user is again reminded via nag of required
+         * This ensures that the user(s) is/are again reminded via nag of required
          * and/or recommended plugins if they re-activate the theme.
          *
          * @since 2.1.1
          */
         public function update_dismiss() {
 
-            delete_user_meta( get_current_user_id(), 'tgmpa_dismissed_notice' );
+            delete_metadata( 'user', null, 'tgmpa_dismissed_notice', null, true );
 
         }
 


### PR DESCRIPTION
There may be several admin users for a site. If a theme using TGMPA is deactivated, the dismiss notice state would only be removed for the user doing the theme switching, not for all users.
This effectively meant that only that user would be re-notified of open recommended/required plugins if the theme would be reactivated.

This fix ensures that all eligable users will be re-notified on reatcivation of the theme using TGMPA.

Sister-PR to PR #246