### PR TITLE
Bump version to 2.4.1 and update changelog

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ See https://github.com/thomasgriffin/TGM-Plugin-Activation/issues for current is
 
 ## Changelog ##
 
+### 2.4.1 ###
+* Escape urls for `add_query_arg` calls
+* Removed call to deprecated `function screen_icon()`
+
 ### 2.4.0 ###
 
 * All textdomain strings now made to `tgmpa` and remove all notices dealing with textdomain and translation issues.

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ See https://github.com/thomasgriffin/TGM-Plugin-Activation/issues for current is
 ## Changelog ##
 
 ### 2.4.1 ###
-* Escape urls for `add_query_arg` calls
+* Escaped urls for `add_query_arg` calls
 * Removed call to deprecated `function screen_icon()`
 
 ### 2.4.0 ###

--- a/class-tgm-plugin-activation.php
+++ b/class-tgm-plugin-activation.php
@@ -3,7 +3,7 @@
  * Plugin installation and activation for WordPress themes.
  *
  * @package   TGM-Plugin-Activation
- * @version   2.4.0
+ * @version   2.4.1
  * @author    Thomas Griffin <thomasgriffinmedia.com>
  * @author    Gary Jones <gamajo.com>
  * @copyright Copyright (c) 2012, Thomas Griffin


### PR DESCRIPTION
Have bumped version to 2.4.1 and updated the change log to include both today's change of escaping add_query_arg and the previous change of removing call to deprecated `function screen_icon()`