### PR TITLE
Fix #292 Add esc_url to only the required locations

### DIFF
--- a/class-tgm-plugin-activation.php
+++ b/class-tgm-plugin-activation.php
@@ -479,6 +479,8 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
                     $url .= add_query_arg( 'from', urlencode( stripslashes( $_GET['from'] ) ), $url );
                 }
 
+                $url = esc_url( $url );
+
                 $nonce = 'install-plugin_' . $plugin['slug'];
 
                 // Prefix a default path to pre-packaged plugins.
@@ -729,7 +731,7 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
                     array(
                         'install'  => ( current_user_can( 'install_plugins' ) )  ? $show_install_link  : '',
                         'activate' => ( current_user_can( 'activate_plugins' ) ) ? $show_activate_link : '',
-                        'dismiss'  => $this->dismissable ? '<a class="dismiss-notice" href="' . add_query_arg( 'tgmpa-dismiss', 'dismiss_admin_notices' ) . '" target="_parent">' . $this->strings['dismiss'] . '</a>' : '',
+                        'dismiss'  => $this->dismissable ? '<a class="dismiss-notice" href="' . esc_url( add_query_arg( 'tgmpa-dismiss', 'dismiss_admin_notices' ) ). '" target="_parent">' . $this->strings['dismiss'] . '</a>' : '',
                     )
                 );
 

--- a/class-tgm-plugin-activation.php
+++ b/class-tgm-plugin-activation.php
@@ -429,17 +429,15 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
 
                 // Pass all necessary information via URL if WP_Filesystem is needed.
                 $url = wp_nonce_url(
-                    esc_url( 
-                        add_query_arg(
-                            array(
-                                'page'          => $this->menu,
-                                'plugin'        => $plugin['slug'],
-                                'plugin_name'   => $plugin['name'],
-                                'plugin_source' => $plugin['source'],
-                                'tgmpa-install' => 'install-plugin',
-                            ),
-                            network_admin_url( 'themes.php' )
-                        )
+                    add_query_arg(
+                        array(
+                            'page'          => $this->menu,
+                            'plugin'        => $plugin['slug'],
+                            'plugin_name'   => $plugin['name'],
+                            'plugin_source' => $plugin['source'],
+                            'tgmpa-install' => 'install-plugin',
+                        ),
+                        network_admin_url( 'themes.php' )
                     ),
                     'tgmpa-install'
                 );
@@ -481,8 +479,6 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
                     $url .= add_query_arg( 'from', urlencode( stripslashes( $_GET['from'] ) ), $url );
                 }
 
-                $url = esc_url( $url );
-
                 $nonce = 'install-plugin_' . $plugin['slug'];
 
                 // Prefix a default path to pre-packaged plugins.
@@ -505,7 +501,7 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
 
                     if ( is_wp_error( $activate ) ) {
                         echo '<div id="message" class="error"><p>' . $activate->get_error_message() . '</p></div>';
-                        echo '<p><a href="' . esc_url( add_query_arg( 'page', $this->menu, network_admin_url( 'themes.php' ) ) ) . '" title="' . esc_attr( $this->strings['return'] ) . '" target="_parent">' . $this->strings['return'] . '</a></p>';
+                        echo '<p><a href="' . add_query_arg( 'page', $this->menu, network_admin_url( 'themes.php' ) ) . '" title="' . esc_attr( $this->strings['return'] ) . '" target="_parent">' . $this->strings['return'] . '</a></p>';
                         return true; // End it here if there is an error with automatic activation
                     }
                     else {
@@ -517,7 +513,7 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
                 $complete = array();
                 foreach ( $this->plugins as $plugin ) {
                     if ( ! is_plugin_active( $plugin['file_path'] ) ) {
-                        echo '<p><a href="' . esc_url( add_query_arg( 'page', $this->menu, network_admin_url( 'themes.php' ) ) ) . '" title="' . esc_attr( $this->strings['return'] ) . '" target="_parent">' . $this->strings['return'] . '</a></p>';
+                        echo '<p><a href="' . add_query_arg( 'page', $this->menu, network_admin_url( 'themes.php' ) ) . '" title="' . esc_attr( $this->strings['return'] ) . '" target="_parent">' . $this->strings['return'] . '</a></p>';
                         $complete[] = $plugin;
                         break;
                     }
@@ -554,7 +550,7 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
 
                 if ( is_wp_error( $activate ) ) {
                     echo '<div id="message" class="error"><p>' . $activate->get_error_message() . '</p></div>';
-                    echo '<p><a href="' . esc_url( add_query_arg( 'page', $this->menu, network_admin_url( 'themes.php' ) ) ) . '" title="' . esc_attr( $this->strings['return'] ) . '" target="_parent">' . $this->strings['return'] . '</a></p>';
+                    echo '<p><a href="' . add_query_arg( 'page', $this->menu, network_admin_url( 'themes.php' ) ) . '" title="' . esc_attr( $this->strings['return'] ) . '" target="_parent">' . $this->strings['return'] . '</a></p>';
                     return true; // End it here if there is an error with activation.
                 }
                 else {
@@ -695,17 +691,15 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
                             $linked_plugin_groups[] = '<a href="' . esc_url( $external_url ) . '" title="' . $plugin_group_single_name . '" target="_blank">' . $plugin_group_single_name . '</a>';
                         }
                         elseif ( ! $source || preg_match( '|^http://wordpress.org/extend/plugins/|', $source ) ) {
-                            $url = esc_url( 
-                                add_query_arg(
-                                    array(
-                                        'tab'       => 'plugin-information',
-                                        'plugin'    => $this->_get_plugin_data_from_name( $plugin_group_single_name ),
-                                        'TB_iframe' => 'true',
-                                        'width'     => '640',
-                                        'height'    => '500',
-                                    ),
-                                    network_admin_url( 'plugin-install.php' )
-                                )
+                            $url = add_query_arg(
+                                array(
+                                    'tab'       => 'plugin-information',
+                                    'plugin'    => $this->_get_plugin_data_from_name( $plugin_group_single_name ),
+                                    'TB_iframe' => 'true',
+                                    'width'     => '640',
+                                    'height'    => '500',
+                                ),
+                                network_admin_url( 'plugin-install.php' )
                             );
 
                             $linked_plugin_groups[] = '<a href="' . esc_url( $url ) . '" class="thickbox" title="' . $plugin_group_single_name . '">' . $plugin_group_single_name . '</a>';
@@ -726,8 +720,8 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
                 }
 
                 // Setup variables to determine if action links are needed.
-                $show_install_link  = $install_link ? '<a href="' . esc_url( add_query_arg( 'page', $this->menu, network_admin_url( 'themes.php' ) ) ) . '">' . translate_nooped_plural( $this->strings['install_link'], $install_link_count, 'tgmpa' ) . '</a>' : '';
-                $show_activate_link = $activate_link ? '<a href="' . esc_url( add_query_arg( 'page', $this->menu, network_admin_url( 'themes.php' ) ) ) . '">' . translate_nooped_plural( $this->strings['activate_link'], $activate_link_count, 'tgmpa' ) . '</a>'  : '';
+                $show_install_link  = $install_link ? '<a href="' . add_query_arg( 'page', $this->menu, network_admin_url( 'themes.php' ) ) . '">' . translate_nooped_plural( $this->strings['install_link'], $install_link_count, 'tgmpa' ) . '</a>' : '';
+                $show_activate_link = $activate_link ? '<a href="' . add_query_arg( 'page', $this->menu, network_admin_url( 'themes.php' ) ) . '">' . translate_nooped_plural( $this->strings['activate_link'], $activate_link_count, 'tgmpa' ) . '</a>'  : '';
 
                 // Define all of the action links.
                 $action_links = apply_filters(
@@ -735,7 +729,7 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
                     array(
                         'install'  => ( current_user_can( 'install_plugins' ) )  ? $show_install_link  : '',
                         'activate' => ( current_user_can( 'activate_plugins' ) ) ? $show_activate_link : '',
-                        'dismiss'  => $this->dismissable ? '<a class="dismiss-notice" href="' . esc_url( add_query_arg( 'tgmpa-dismiss', 'dismiss_admin_notices' ) ) . '" target="_parent">' . $this->strings['dismiss'] . '</a>' : '',
+                        'dismiss'  => $this->dismissable ? '<a class="dismiss-notice" href="' . add_query_arg( 'tgmpa-dismiss', 'dismiss_admin_notices' ) . '" target="_parent">' . $this->strings['dismiss'] . '</a>' : '',
                     )
                 );
 
@@ -1145,17 +1139,15 @@ if ( ! class_exists( 'TGMPA_List_Table' ) ) {
                     $table_data[$i]['plugin'] = '<strong><a href="' . esc_url( $external_url ) . '" title="' . $plugin['name'] . '" target="_blank">' . $plugin['name'] . '</a></strong>';
                 }
                 elseif ( ! $source || preg_match( '|^http://wordpress.org/extend/plugins/|', $source ) ) {
-                    $url = esc_url( 
-                        add_query_arg(
-                            array(
-                                'tab'       => 'plugin-information',
-                                'plugin'    => $this->_get_plugin_data_from_name( $plugin['name'] ),
-                                'TB_iframe' => 'true',
-                                'width'     => '640',
-                                'height'    => '500',
-                            ),
-                            network_admin_url( 'plugin-install.php' )
-                        )
+                    $url = add_query_arg(
+                        array(
+                            'tab'       => 'plugin-information',
+                            'plugin'    => $this->_get_plugin_data_from_name( $plugin['name'] ),
+                            'TB_iframe' => 'true',
+                            'width'     => '640',
+                            'height'    => '500',
+                        ),
+                        network_admin_url( 'plugin-install.php' )
                     );
 
                     $table_data[$i]['plugin'] = '<strong><a href="' . esc_url( $url ) . '" class="thickbox" title="' . $plugin['name'] . '">' . $plugin['name'] . '</a></strong>';
@@ -1294,17 +1286,15 @@ if ( ! class_exists( 'TGMPA_List_Table' ) ) {
                     'install' => sprintf(
                         '<a href="%1$s" title="' . __( 'Install', 'tgmpa' ) . ' %2$s">' . __( 'Install', 'tgmpa' ) . '</a>',
                         wp_nonce_url(
-                            esc_url(
-                                add_query_arg(
-                                    array(
-                                        'page'          => TGM_Plugin_Activation::$instance->menu,
-                                        'plugin'        => $item['slug'],
-                                        'plugin_name'   => $item['sanitized_plugin'],
-                                        'plugin_source' => $item['url'],
-                                        'tgmpa-install' => 'install-plugin',
-                                    ),
-                                    network_admin_url( 'themes.php' )
-                                )
+                            add_query_arg(
+                                array(
+                                    'page'          => TGM_Plugin_Activation::$instance->menu,
+                                    'plugin'        => $item['slug'],
+                                    'plugin_name'   => $item['sanitized_plugin'],
+                                    'plugin_source' => $item['url'],
+                                    'tgmpa-install' => 'install-plugin',
+                                ),
+                                network_admin_url( 'themes.php' )
                             ),
                             'tgmpa-install'
                         ),
@@ -1317,18 +1307,16 @@ if ( ! class_exists( 'TGMPA_List_Table' ) ) {
                 $actions = array(
                     'activate' => sprintf(
                         '<a href="%1$s" title="' . __( 'Activate', 'tgmpa' ) . ' %2$s">' . __( 'Activate', 'tgmpa' ) . '</a>',
-                        esc_url( 
-                            add_query_arg(
-                                array(
-                                    'page'                 => TGM_Plugin_Activation::$instance->menu,
-                                    'plugin'               => $item['slug'],
-                                    'plugin_name'          => $item['sanitized_plugin'],
-                                    'plugin_source'        => $item['url'],
-                                    'tgmpa-activate'       => 'activate-plugin',
-                                    'tgmpa-activate-nonce' => wp_create_nonce( 'tgmpa-activate' ),
-                                ),
-                                network_admin_url( 'themes.php' )
-                            )
+                        add_query_arg(
+                            array(
+                                'page'                 => TGM_Plugin_Activation::$instance->menu,
+                                'plugin'               => $item['slug'],
+                                'plugin_name'          => $item['sanitized_plugin'],
+                                'plugin_source'        => $item['url'],
+                                'tgmpa-activate'       => 'activate-plugin',
+                                'tgmpa-activate-nonce' => wp_create_nonce( 'tgmpa-activate' ),
+                            ),
+                            network_admin_url( 'themes.php' )
                         ),
                         $item['sanitized_plugin']
                     ),
@@ -1529,17 +1517,15 @@ if ( ! class_exists( 'TGMPA_List_Table' ) ) {
 
                 // Pass all necessary information via URL if WP_Filesystem is needed.
                 $url = wp_nonce_url(
-                    esc_url( 
-                        add_query_arg(
-                            array(
-                                'page'          => TGM_Plugin_Activation::$instance->menu,
-                                'tgmpa-action'  => 'install-selected',
-                                'plugins'       => urlencode( implode( ',', $plugins ) ),
-                                'plugin_paths'  => urlencode( implode( ',', $plugin_paths ) ),
-                                'plugin_names'  => urlencode( implode( ',', $plugin_names ) ),
-                            ),
-                            network_admin_url( 'themes.php' )
-                        )
+                    add_query_arg(
+                        array(
+                            'page'          => TGM_Plugin_Activation::$instance->menu,
+                            'tgmpa-action'  => 'install-selected',
+                            'plugins'       => urlencode( implode( ',', $plugins ) ),
+                            'plugin_paths'  => urlencode( implode( ',', $plugin_paths ) ),
+                            'plugin_names'  => urlencode( implode( ',', $plugin_names ) ),
+                        ),
+                        network_admin_url( 'themes.php' )
                     ),
                     'bulk-plugins'
                 );
@@ -1582,7 +1568,7 @@ if ( ! class_exists( 'TGMPA_List_Table' ) ) {
                 }
 
                 // Finally, all the data is prepared to be sent to the installer.
-                $url   = esc_url( add_query_arg( array( 'page' => TGM_Plugin_Activation::$instance->menu ), network_admin_url( 'themes.php' ) ) );
+                $url   = add_query_arg( array( 'page' => TGM_Plugin_Activation::$instance->menu ), network_admin_url( 'themes.php' ) );
                 $nonce = 'bulk-plugins';
                 $names = $plugin_names;
 
@@ -2152,7 +2138,7 @@ if ( ! class_exists( 'WP_Upgrader' ) && ( isset( $_GET['page'] ) && TGM_Plugin_A
                 $complete = array();
                 foreach ( TGM_Plugin_Activation::$instance->plugins as $plugin ) {
                     if ( ! is_plugin_active( $plugin['file_path'] ) ) {
-                        echo '<p><a href="' . esc_url( add_query_arg( 'page', TGM_Plugin_Activation::$instance->menu, network_admin_url( 'themes.php' ) ) ) . '" title="' . esc_attr( TGM_Plugin_Activation::$instance->strings['return'] ) . '" target="_parent">' . TGM_Plugin_Activation::$instance->strings['return'] . '</a></p>';
+                        echo '<p><a href="' . add_query_arg( 'page', TGM_Plugin_Activation::$instance->menu, network_admin_url( 'themes.php' ) ) . '" title="' . esc_attr( TGM_Plugin_Activation::$instance->strings['return'] ) . '" target="_parent">' . TGM_Plugin_Activation::$instance->strings['return'] . '</a></p>';
                         $complete[] = $plugin;
                         break;
                     }


### PR DESCRIPTION
Fixes #292

This PR reverts the `esc_url` commit that broke installation and only applies the `esc_url` escaping to two places where unsafe URLs could be delivered to the HTML.

I believe these are the only two places where URLs need to be escaped. I took a look at the other places where user input is passed via `add_query_arg`, but as far as I could tell the filesystem calls and plugin installers properly sanitize the plugin slugs used for file lookups and installs.

I'd really appreciate a second look at this, though.