### PR TITLE
Allow other plugins to filter the action links similar to WP Core

### DIFF
--- a/class-tgm-plugin-activation.php
+++ b/class-tgm-plugin-activation.php
@@ -1425,6 +1425,9 @@ if ( ! class_exists( 'TGMPA_List_Table' ) ) {
 				);
 			}
 
+			$prefix  = ( defined( 'WP_NETWORK_ADMIN' ) && WP_NETWORK_ADMIN ) ? 'network_admin_' : '';
+			$actions = apply_filters( "tgmpa_${prefix}plugin_action_links", array_filter( $actions ), $item['slug'] );
+
 			return sprintf( '%1$s %2$s', $item['plugin'], $this->row_actions( $actions ) );
 
 		}

--- a/class-tgm-plugin-activation.php
+++ b/class-tgm-plugin-activation.php
@@ -1426,7 +1426,7 @@ if ( ! class_exists( 'TGMPA_List_Table' ) ) {
 			}
 
 			$prefix  = ( defined( 'WP_NETWORK_ADMIN' ) && WP_NETWORK_ADMIN ) ? 'network_admin_' : '';
-			$actions = apply_filters( "tgmpa_${prefix}plugin_action_links", array_filter( $actions ), $item['slug'] );
+			$actions = apply_filters( "tgmpa_{$prefix}plugin_action_links", array_filter( $actions ), $item['slug'] );
 
 			return sprintf( '%1$s %2$s', $item['plugin'], $this->row_actions( $actions ) );
 


### PR DESCRIPTION
See #226.

Follows WP core naming, but with our consistent prefix (`tgmpa_`). 