### PR TITLE
Fix bulk install displaying TGM table after finished

### DIFF
--- a/class-tgm-plugin-activation.php
+++ b/class-tgm-plugin-activation.php
@@ -426,7 +426,7 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
 			$plugin_table = new TGMPA_List_Table;
 
 			// Return early if processing a plugin installation action.
-			if ( isset( $_POST['action'] ) && 'tgmpa-bulk-install' === $_POST['action'] && $plugin_table->process_bulk_actions() || $this->do_plugin_install() ) {
+			if ( ( 'tgmpa-bulk-install' === $plugin_table->current_action() && $plugin_table->process_bulk_actions() ) || $this->do_plugin_install() ) {
 				return;
 			}
 


### PR DESCRIPTION
Fixes the table displaying after the bulk display has finished (and the notice boxes jumping up) - see screenshot to see what went wrong.

Basically the table has two bulk action dropdowns and the if statement only looked at the action result in `$_POST` for the top one, not the bottom one.

The resulting table displayed would be out of date and the screen layout screwed up.

![screenshot](http://snag.gy/LqWc0.jpg)