### PR TITLE
Only flush the plugins cache, not *all* WP caches.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Contributors:** Thomas Griffin (@jthomasgriffin / thomasgriffinmedia.com), Gary Jones (Github: @GaryJones / Twitter: GaryJ)  
 **Version:** 2.4.1  
-**Requires at least:** 3.0.0  
+**Requires at least:** 3.7.0  
 **Tested up to:** 4.2  
 
 ## Description

--- a/class-tgm-plugin-activation.php
+++ b/class-tgm-plugin-activation.php
@@ -555,7 +555,7 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
 				$upgrader->install( $source );
 
 				// Flush plugins cache so we can make sure that the installed plugins list is always up to date.
-				wp_cache_flush();
+				$this->flush_plugins_cache();
 
 				// Only activate plugins if the config option is set to true.
 				if ( $this->is_automatic ) {
@@ -942,7 +942,7 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
 		 */
 		public function flush_plugins_cache() {
 
-			wp_cache_flush();
+			wp_clean_plugins_cache();
 
 		}
 
@@ -2047,7 +2047,7 @@ if ( ! function_exists( 'tgmpa_load_bulk_installer' ) ) {
 						// Only process the activation of installed plugins if the automatic flag is set to true.
 						if ( $this->tgmpa->is_automatic ) {
 							// Flush plugins cache so we can make sure that the installed plugins list is always up to date.
-							wp_cache_flush();
+							wp_clean_plugins_cache();
 
 							// Get the installed plugin file and activate it.
 							$plugin_info = $this->plugin_info( $options['package'] );
@@ -2068,7 +2068,7 @@ if ( ! function_exists( 'tgmpa_load_bulk_installer' ) ) {
 						}
 
 						// Flush plugins cache so we can make sure that the installed plugins list is always up to date.
-						wp_cache_flush();
+						wp_clean_plugins_cache();
 
 						// Set install footer strings.
 						$this->skin->after();
@@ -2313,7 +2313,7 @@ if ( ! function_exists( 'tgmpa_load_bulk_installer' ) ) {
 						parent::bulk_footer();
 
 						// Flush plugins cache so we can make sure that the installed plugins list is always up to date.
-						wp_cache_flush();
+						wp_clean_plugins_cache();
 
 						// Display message based on if all plugins are now active or not.
 						$complete = array();


### PR DESCRIPTION
This will save a lot of overhead of other (page/metadata) caches having to be recreated because we flushed them.

This function was introduced in WP 3.7, so requires upping the minimum requirement of TGMPA.

Alternatively - if we wouldn't want to up the minimum requirement yet -, we could wrap this in a `function_exists()` if then else block.

[Edit]
Looking into this further, we could also choose to remove the flush calls completely and just up the minimum requirements as a quick check shows that WP 3.7+ will flush the plugin cache already. This, however, would need to be thoroughly checked for all situations in which we flush the cache.