### PR TITLE
Update Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,40 +10,41 @@ language: php
 
 # Declare versions of PHP to use. Use one decimal max.
 php:
-    # Aliased to a recent high PHP version
-    - 5.6
-    # Might as well test HHVM too
-    - hhvm
-    # Lowest currently possible in travis
     - 5.2
+    - 5.6
+    - hhvm
+
+matrix:
+    allow_failures:
+        - php: hhvm
 
 before_script:
+    - export PHPCS_DIR=/tmp/phpcs
+    - export WPCS_DIR=/tmp/wpcs
     # Install CodeSniffer for WordPress Coding Standards checks.
-    - git clone https://github.com/squizlabs/PHP_CodeSniffer.git phpcs
+    # 2.3.1 breaks PHP 5.2 on Travis due to use of Phar class.
+    - git clone -b 2.3.0 --depth 1 https://github.com/squizlabs/PHP_CodeSniffer.git $PHPCS_DIR
     # Install WordPress Coding Standards.
-    - git clone -b master https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards.git wpcs
-    # Hop into CodeSniffer directory.
-    - cd phpcs
+    - git clone -b master --depth 1 https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards.git $WPCS_DIR
     # Set install path for WordPress Coding Standards.
     # @link https://github.com/squizlabs/PHP_CodeSniffer/blob/4237c2fc98cc838730b76ee9cee316f99286a2a7/CodeSniffer.php#L1941
-    - scripts/phpcs --config-set installed_paths ../wpcs
-    # Hop into project dir.
-    - cd $TRAVIS_BUILD_DIR
+    - $PHPCS_DIR/scripts/phpcs --config-set installed_paths $WPCS_DIR
     # After CodeSniffer install you should refresh your path.
     - phpenv rehash
 
 # Run test script commands.
 # All commands must exit with code 0 on success. Anything else is considered failure.
 script:
-    # Search for PHP syntax errors. Ignore the phpcs and wpcs directories.
-    - find -L . -path "./*pcs" -prune -o -name '*.php' -print0 | xargs -0 -n 1 -P 4 php -l;
+    # Search for PHP syntax errors.
+    - find . \( -name '*.php' \) -exec php -lf {} \;
     # WordPress Coding Standards
     # @link https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
-    # @link http://pear.php.net/package/PHP_CodeSniffer/
+    # @link https://github.com/squizlabs/PHP_CodeSniffer
     # -p flag: Show progress of the run.
     # -s flag: Show sniff codes in all reports.
     # -v flag: Print verbose output.
     # -n flag: Do not print warnings (shortcut for --warning-severity=0)
-    # --standard: Use WordPress as the standard.
+    # --standard: Use WordPress (not VIP) as the standard.
     # --extensions: Only sniff PHP files.
-    - $TRAVIS_BUILD_DIR/phpcs/scripts/phpcs -p -s -v -n . --standard=./ruleset.xml --extensions=php
+    # --report: Show a summary report.
+    - $PHPCS_DIR/scripts/phpcs -p -s -v -n . --standard=./ruleset.xml --extensions=php --report=summary


### PR DESCRIPTION
* Allow HHVM to fail.
* Put PHPCS and WPCS into `/tmp/` subdirectories so they don't have to be excluded from linting.
* Use 2.3.0 tag of PHPCS, since master (currently 2.3.1) includes a call to `Phar` class.
* Specify master branch of WPCS, which is more stable than default (develop) branch.
* Simplify linting command.
* Clarify WPCS standard.
* Add summary report for PHPCS.

Tested against a fork of this repo, since this repo is not yet hooked up to Travis.