### PR TITLE
Configure .editorconfig for IDE

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,4 +1,9 @@
+# This file is for unifying the coding style for different editors and IDEs
 # editorconfig.org
+
+# WordPress Coding Standards
+# http://make.wordpress.org/core/handbook/coding-standards/
+
 root = true
 
 [*]
@@ -12,6 +17,8 @@ trim_trailing_whitespace = true
 
 [*.md]
 trim_trailing_whitespace = false
+indent_style = space
+indent_size = 2
 
 [*.yml]
 insert_final_newline = false

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,19 @@
+# editorconfig.org
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 4
+tab_width = 4
+indent_style = tab
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.yml]
+insert_final_newline = false
+indent_style = space
+indent_size = 2

--- a/.editorconfig
+++ b/.editorconfig
@@ -15,12 +15,7 @@ indent_style = tab
 insert_final_newline = true
 trim_trailing_whitespace = true
 
-[*.md]
+[*.{md,yml}]
 trim_trailing_whitespace = false
-indent_style = space
-indent_size = 2
-
-[*.yml]
-insert_final_newline = false
 indent_style = space
 indent_size = 2


### PR DESCRIPTION
@GaryJones this not work very well:

```
[{*.md,*.yml}]
```

Usually works with full names like:

```
[{README.md,.coveralls.yml,.etc.yml}]
```

I'm using with VIM and Sublime and does not work. Impossible to use something unstable only for satisfaction of saving three lines in a configuration file.
;)