### PR TITLE
Lean loading: only really load TGMPA when on the admin side

### DIFF
--- a/class-tgm-plugin-activation.php
+++ b/class-tgm-plugin-activation.php
@@ -220,6 +220,10 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
 		 * @see TGM_Plugin_Activation::styles()
 		 */
 		public function init() {
+			
+			if ( apply_filters( 'tgmpa_load', ! is_admin() ) ) {
+				return;
+			}
 
 			// Load class strings.
 			$this->strings = array(


### PR DESCRIPTION
Needs review - AFAICS everything hooks into admin side hooks, so there shouldn't be a need to register plugins/config when not in admin.
The only caveat to this I can think of is in a develop environment where some developers use a 'switch_theme' plugin which can be used from the admin bar.