### PR TITLE
Add updating workflow

### DIFF
--- a/class-tgm-plugin-activation.php
+++ b/class-tgm-plugin-activation.php
@@ -295,7 +295,7 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
 					'The following plugins need to be updated to their latest version to ensure maximum compatibility with this theme: %1$s.',
 					'tgmpa'
 				),
-				'notice_can_update'               => _n_noop(
+				'notice_ask_to_update_maybe'      => _n_noop(
 					'There is an update available for: %1$s.',
 					'There are updates available for the following plugins: %1$s.',
 					'tgmpa'
@@ -1030,7 +1030,7 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
 								$message['notice_ask_to_update'][] = $slug;
 							}
 							elseif ( false !== $this->does_plugin_have_update( $slug ) ) {
-								$message['notice_can_update'][] = $slug;
+								$message['notice_ask_to_update_maybe'][] = $slug;
 							}
 						}
 						// Need higher privileges to update the plugin.

--- a/class-tgm-plugin-activation.php
+++ b/class-tgm-plugin-activation.php
@@ -1118,10 +1118,13 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
 		 * from remaining in the plugin table.
 		 *
 		 * @since 2.4.0
+		 *
+		 * @param bool $clear_update_cache Optional. Whether to clear the Plugin updates cache.
+		 *                                 Parameter added in v2.5.0.
 		 */
-		public function flush_plugins_cache() {
+		public function flush_plugins_cache( $clear_update_cache = true ) {
 
-			wp_clean_plugins_cache();
+			wp_clean_plugins_cache( $clear_update_cache );
 
 		}
 

--- a/class-tgm-plugin-activation.php
+++ b/class-tgm-plugin-activation.php
@@ -2916,6 +2916,8 @@ if ( ! function_exists( 'tgmpa_load_bulk_installer' ) ) {
 						if ( $this->tgmpa->is_automatic ) {
 							$this->activate_strings();
 						}
+
+						add_action( 'upgrader_process_complete', array( $this->tgmpa, 'populate_file_path' ) );
 					}
 
 					/**
@@ -3096,9 +3098,6 @@ if ( ! function_exists( 'tgmpa_load_bulk_installer' ) ) {
 						// Force refresh of plugin update information
 						wp_clean_plugins_cache( $parsed_args['clear_update_cache'] );
 
-						// [TGMPA + ] Make sure we have the correct file paths now the plugins are installed/updated.
-						$this->tgmpa->populate_file_path();
-
 						return $results;
 					}
 
@@ -3120,8 +3119,6 @@ if ( ! function_exists( 'tgmpa_load_bulk_installer' ) ) {
 						$result = parent::bulk_upgrade( $plugins, $args );
 
 						remove_filter( 'upgrader_post_install', array( $this, 'auto_activate' ), 10, 3 );
-
-						$this->tgmpa->populate_file_path();
 
 						return $result;
 					}

--- a/example.php
+++ b/example.php
@@ -130,7 +130,7 @@ function my_theme_register_required_plugins() {
 				'The following plugins need to be updated to their latest version to ensure maximum compatibility with this theme: %1$s.',
 				'theme-slug'
 			), // %1$s = plugin name(s).
-			'notice_can_update'               => _n_noop(
+			'notice_ask_to_update_maybe'      => _n_noop(
 				'There is an update available for: %1$s.',
 				'There are updates available for the following plugins: %1$s.',
 				'theme-slug'

--- a/example.php
+++ b/example.php
@@ -48,7 +48,7 @@ function my_theme_register_required_plugins() {
 			'slug'               => 'tgm-example-plugin', // The plugin slug (typically the folder name).
 			'source'             => get_stylesheet_directory() . '/lib/plugins/tgm-example-plugin.zip', // The plugin source.
 			'required'           => true, // If false, the plugin is only 'recommended' instead of required.
-			'version'            => '', // E.g. 1.0.0. If set, the active plugin must be this version or higher.
+			'version'            => '', // E.g. 1.0.0. If set, the active plugin must be this version or higher. If the plugin version is higher than the plugin version installed, the user will be notified to update the plugin.
 			'force_activation'   => false, // If true, plugin is activated upon theme activation and cannot be deactivated until theme switch.
 			'force_deactivation' => false, // If true, plugin is deactivated upon theme switch, useful for theme-specific plugins.
 			'external_url'       => '', // If set, overrides default API URL and points to an external URL.
@@ -84,8 +84,13 @@ function my_theme_register_required_plugins() {
 
 	/*
 	 * Array of configuration settings. Amend each line as needed.
-	 * If you want the default strings to be available under your own theme domain,
-	 * leave the strings uncommented.
+	 *
+	 * TGMPA will start providing localized text strings soon. If you already have translations of our standard
+	 * strings available, please help us make TGMPA even better by giving us access to these translations or by
+	 * sending in a pull-request with .po file(s) with the translations.
+	 *
+	 * Only uncomment the strings in the config array if you want to customize the strings.
+	 *
 	 * Some of the strings are wrapped in a sprintf(), so see the comments at the
 	 * end of each line for what each argument will be.
 	 */
@@ -116,8 +121,23 @@ function my_theme_register_required_plugins() {
 				'theme-slug'
 			), // %1$s = plugin name(s).
 			'notice_cannot_install'           => _n_noop(
-				'Sorry, but you do not have the correct permissions to install the %s plugin.',
-				'Sorry, but you do not have the correct permissions to install the %s plugins.',
+				'Sorry, but you do not have the correct permissions to install the %1$s plugin.',
+				'Sorry, but you do not have the correct permissions to install the %1$s plugins.',
+				'theme-slug'
+			), // %1$s = plugin name(s).
+			'notice_ask_to_update'            => _n_noop(
+				'The following plugin needs to be updated to its latest version to ensure maximum compatibility with this theme: %1$s.',
+				'The following plugins need to be updated to their latest version to ensure maximum compatibility with this theme: %1$s.',
+				'theme-slug'
+			), // %1$s = plugin name(s).
+			'notice_can_update'               => _n_noop(
+				'There is an update available for: %1$s.',
+				'There are updates available for the following plugins: %1$s.',
+				'theme-slug'
+			), // %1$s = plugin name(s).
+			'notice_cannot_update'            => _n_noop(
+				'Sorry, but you do not have the correct permissions to update the %1$s plugin.',
+				'Sorry, but you do not have the correct permissions to update the %1$s plugins.',
 				'theme-slug'
 			), // %1$s = plugin name(s).
 			'notice_can_activate_required'    => _n_noop(
@@ -131,23 +151,18 @@ function my_theme_register_required_plugins() {
 				'theme-slug'
 			), // %1$s = plugin name(s).
 			'notice_cannot_activate'          => _n_noop(
-				'Sorry, but you do not have the correct permissions to activate the %s plugin.',
-				'Sorry, but you do not have the correct permissions to activate the %s plugins.',
-				'theme-slug'
-			), // %1$s = plugin name(s).
-			'notice_ask_to_update'            => _n_noop(
-				'The following plugin needs to be updated to its latest version to ensure maximum compatibility with this theme: %1$s.',
-				'The following plugins need to be updated to their latest version to ensure maximum compatibility with this theme: %1$s.',
-				'theme-slug'
-			), // %1$s = plugin name(s).
-			'notice_cannot_update'            => _n_noop(
-				'Sorry, but you do not have the correct permissions to update the %s plugin.',
-				'Sorry, but you do not have the correct permissions to update the %s plugins.',
+				'Sorry, but you do not have the correct permissions to activate the %1$s plugin.',
+				'Sorry, but you do not have the correct permissions to activate the %1$s plugins.',
 				'theme-slug'
 			), // %1$s = plugin name(s).
 			'install_link'                    => _n_noop(
 				'Begin installing plugin',
 				'Begin installing plugins',
+				'theme-slug'
+			),
+			'update_link' 					  => _n_noop(
+				'Begin updating plugin',
+				'Begin updating plugins',
 				'theme-slug'
 			),
 			'activate_link'                   => _n_noop(
@@ -157,7 +172,10 @@ function my_theme_register_required_plugins() {
 			),
 			'return'                          => __( 'Return to Required Plugins Installer', 'theme-slug' ),
 			'plugin_activated'                => __( 'Plugin activated successfully.', 'theme-slug' ),
-			'complete'                        => __( 'All plugins installed and activated successfully. %s', 'theme-slug' ), // %s = dashboard link.
+			'activated_successfully'          => __( 'The following plugin was activated successfully:', 'theme-slug' ),
+			'plugin_already_active'           => __( 'No action taken. Plugin %1$s was already active.', 'theme-slug' ),  // %1$s = plugin name(s).
+			'plugin_needs_higher_version'     => __( 'Plugin not activated. A higher version of %s is needed for this theme. Please update the plugin.', 'theme-slug' ),  // %1$s = plugin name(s).
+			'complete'                        => __( 'All plugins installed and activated successfully. %1$s', 'theme-slug' ), // %s = dashboard link.
 			'contact_admin'                   => __( 'Please contact the administrator of this site for help.', 'tgmpa' ),
 
 			'nag_type'                        => 'updated', // Determines admin notice type - can only be 'updated', 'update-nag' or 'error'.

--- a/languages/tgmpa.pot
+++ b/languages/tgmpa.pot
@@ -1,0 +1,442 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: TGM-Plugin-Activation\n"
+"POT-Creation-Date: 2015-05-03 05:47+0100\n"
+"PO-Revision-Date: 2015-05-03 05:50+0100\n"
+"Last-Translator: Juliette Reinders Folmer <wpplugins_nospam@adviesenzo.nl>\n"
+"Language-Team: TGMPA\n"
+"Language: en_US\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 1.7.5\n"
+"X-Poedit-Basepath: ..\n"
+"X-Poedit-SourceCharset: UTF-8\n"
+"X-Poedit-KeywordsList: __;_e;_n:1,2;_x:1,2c;_ex:1,2c;_nx:4c,1,2;esc_attr__;"
+"esc_attr_e;esc_attr_x:1,2c;esc_html__;esc_html_e;esc_html_x:1,2c;_n_noop:1,2;"
+"_nx_noop:3c,1,2;__ngettext_noop:1,2\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Poedit-SearchPath-0: .\n"
+"X-Poedit-SearchPathExcluded-0: *.js\n"
+"X-Poedit-SearchPathExcluded-1: example.php\n"
+
+#: class-tgm-plugin-activation.php:274
+msgid "Install Required Plugins"
+msgstr ""
+
+#: class-tgm-plugin-activation.php:275
+msgid "Install Plugins"
+msgstr ""
+
+#: class-tgm-plugin-activation.php:276
+#, php-format
+msgid "Installing Plugin: %s"
+msgstr ""
+
+#: class-tgm-plugin-activation.php:277
+msgid "Something went wrong with the plugin API."
+msgstr ""
+
+#: class-tgm-plugin-activation.php:279
+#, php-format
+msgid "This theme requires the following plugin: %1$s."
+msgid_plural "This theme requires the following plugins: %1$s."
+msgstr[0] ""
+msgstr[1] ""
+
+#: class-tgm-plugin-activation.php:284
+#, php-format
+msgid "This theme recommends the following plugin: %1$s."
+msgid_plural "This theme recommends the following plugins: %1$s."
+msgstr[0] ""
+msgstr[1] ""
+
+#: class-tgm-plugin-activation.php:289
+#, php-format
+msgid ""
+"Sorry, but you do not have the correct permissions to install the %1$s "
+"plugin."
+msgid_plural ""
+"Sorry, but you do not have the correct permissions to install the %1$s "
+"plugins."
+msgstr[0] ""
+msgstr[1] ""
+
+#: class-tgm-plugin-activation.php:294
+#, php-format
+msgid ""
+"The following plugin needs to be updated to its latest version to ensure "
+"maximum compatibility with this theme: %1$s."
+msgid_plural ""
+"The following plugins need to be updated to their latest version to ensure "
+"maximum compatibility with this theme: %1$s."
+msgstr[0] ""
+msgstr[1] ""
+
+#: class-tgm-plugin-activation.php:299
+#, php-format
+msgid "There is an update available for: %1$s."
+msgid_plural "There are updates available for the following plugins: %1$s."
+msgstr[0] ""
+msgstr[1] ""
+
+#: class-tgm-plugin-activation.php:304
+#, php-format
+msgid ""
+"Sorry, but you do not have the correct permissions to update the %1$s plugin."
+msgid_plural ""
+"Sorry, but you do not have the correct permissions to update the %1$s "
+"plugins."
+msgstr[0] ""
+msgstr[1] ""
+
+#: class-tgm-plugin-activation.php:309
+#, php-format
+msgid "The following required plugin is currently inactive: %1$s."
+msgid_plural "The following required plugins are currently inactive: %1$s."
+msgstr[0] ""
+msgstr[1] ""
+
+#: class-tgm-plugin-activation.php:314
+#, php-format
+msgid "The following recommended plugin is currently inactive: %1$s."
+msgid_plural "The following recommended plugins are currently inactive: %1$s."
+msgstr[0] ""
+msgstr[1] ""
+
+#: class-tgm-plugin-activation.php:319
+#, php-format
+msgid ""
+"Sorry, but you do not have the correct permissions to activate the %1$s "
+"plugin."
+msgid_plural ""
+"Sorry, but you do not have the correct permissions to activate the %1$s "
+"plugins."
+msgstr[0] ""
+msgstr[1] ""
+
+#: class-tgm-plugin-activation.php:324
+msgid "Begin installing plugin"
+msgid_plural "Begin installing plugins"
+msgstr[0] ""
+msgstr[1] ""
+
+#: class-tgm-plugin-activation.php:329
+msgid "Begin updating plugin"
+msgid_plural "Begin updating plugins"
+msgstr[0] ""
+msgstr[1] ""
+
+#: class-tgm-plugin-activation.php:334
+msgid "Begin activating plugin"
+msgid_plural "Begin activating plugins"
+msgstr[0] ""
+msgstr[1] ""
+
+#: class-tgm-plugin-activation.php:339
+msgid "Return to Required Plugins Installer"
+msgstr ""
+
+#: class-tgm-plugin-activation.php:340
+msgid "Return to the dashboard"
+msgstr ""
+
+#: class-tgm-plugin-activation.php:341 class-tgm-plugin-activation.php:2872
+msgid "Plugin activated successfully."
+msgstr ""
+
+#: class-tgm-plugin-activation.php:342 class-tgm-plugin-activation.php:2698
+msgid "The following plugin was activated successfully:"
+msgid_plural "The following plugins were activated successfully:"
+msgstr[0] ""
+msgstr[1] ""
+
+#: class-tgm-plugin-activation.php:343
+#, php-format
+msgid "No action taken. Plugin %1$s was already active."
+msgstr ""
+
+#: class-tgm-plugin-activation.php:344
+#, php-format
+msgid ""
+"Plugin not activated. A higher version of %s is needed for this theme. "
+"Please update the plugin."
+msgstr ""
+
+#: class-tgm-plugin-activation.php:345
+#, php-format
+msgid "All plugins installed and activated successfully. %1$s"
+msgstr ""
+
+#: class-tgm-plugin-activation.php:346
+msgid "Dismiss this notice"
+msgstr ""
+
+#: class-tgm-plugin-activation.php:347
+msgid "Please contact the administrator of this site for help."
+msgstr ""
+
+#: class-tgm-plugin-activation.php:462
+msgid "This plugin needs to be updated to be compatible with your theme."
+msgstr ""
+
+#: class-tgm-plugin-activation.php:463
+msgid "Update Required"
+msgstr ""
+
+#: class-tgm-plugin-activation.php:769 class-tgm-plugin-activation.php:3285
+msgid "Return to the Dashboard"
+msgstr ""
+
+#: class-tgm-plugin-activation.php:881
+msgid ""
+"The remote plugin package does not contain a folder with the desired slug "
+"and renaming did not work."
+msgstr ""
+
+#: class-tgm-plugin-activation.php:881 class-tgm-plugin-activation.php:885
+msgid ""
+"Please contact the plugin provider and ask them to package their plugin "
+"according to the WordPress guidelines."
+msgstr ""
+
+#: class-tgm-plugin-activation.php:885
+msgid ""
+"The remote plugin package consists of more than one file, but the files are "
+"not packaged in a folder."
+msgstr ""
+
+#: class-tgm-plugin-activation.php:1072 class-tgm-plugin-activation.php:2694
+msgctxt "plugin A *and* plugin B"
+msgid "and"
+msgstr ""
+
+#: class-tgm-plugin-activation.php:2085
+msgid "Required"
+msgstr ""
+
+#: class-tgm-plugin-activation.php:2087
+msgid "Recommended"
+msgstr ""
+
+#: class-tgm-plugin-activation.php:2104
+msgid "WordPress Repository"
+msgstr ""
+
+#: class-tgm-plugin-activation.php:2108
+msgid "External Source"
+msgstr ""
+
+#: class-tgm-plugin-activation.php:2112
+msgid "Pre-Packaged"
+msgstr ""
+
+#: class-tgm-plugin-activation.php:2129
+msgid "Not Installed"
+msgstr ""
+
+#: class-tgm-plugin-activation.php:2133
+msgid "Installed But Not Activated"
+msgstr ""
+
+#: class-tgm-plugin-activation.php:2135
+msgid "Active"
+msgstr ""
+
+#: class-tgm-plugin-activation.php:2139
+msgid "Required Update not Available"
+msgstr ""
+
+#: class-tgm-plugin-activation.php:2142
+msgid "Requires Update"
+msgstr ""
+
+#: class-tgm-plugin-activation.php:2145
+msgid "Update recommended"
+msgstr ""
+
+#: class-tgm-plugin-activation.php:2194
+#, php-format
+msgctxt "plugins"
+msgid "All <span class=\"count\">(%s)</span>"
+msgid_plural "All <span class=\"count\">(%s)</span>"
+msgstr[0] ""
+msgstr[1] ""
+
+#: class-tgm-plugin-activation.php:2197
+#, php-format
+msgid "To Install <span class=\"count\">(%s)</span>"
+msgid_plural "To Install <span class=\"count\">(%s)</span>"
+msgstr[0] ""
+msgstr[1] ""
+
+#: class-tgm-plugin-activation.php:2200
+#, php-format
+msgid "Update Available <span class=\"count\">(%s)</span>"
+msgid_plural "Update Available <span class=\"count\">(%s)</span>"
+msgstr[0] ""
+msgstr[1] ""
+
+#: class-tgm-plugin-activation.php:2203
+#, php-format
+msgid "To Activate <span class=\"count\">(%s)</span>"
+msgid_plural "To Activate <span class=\"count\">(%s)</span>"
+msgstr[0] ""
+msgstr[1] ""
+
+#: class-tgm-plugin-activation.php:2285
+msgctxt "as in: \"version nr unknown\""
+msgid "unknown"
+msgstr ""
+
+#: class-tgm-plugin-activation.php:2293
+msgid "Installed version:"
+msgstr ""
+
+#: class-tgm-plugin-activation.php:2301
+msgid "Minimum required version:"
+msgstr ""
+
+#: class-tgm-plugin-activation.php:2313
+msgid "Available version:"
+msgstr ""
+
+#: class-tgm-plugin-activation.php:2337
+#, php-format
+msgid ""
+"No plugins to install, update or activate. <a href=\"%1$s\">Return to the "
+"Dashboard</a>"
+msgstr ""
+
+#: class-tgm-plugin-activation.php:2353
+msgid "Plugin"
+msgstr ""
+
+#: class-tgm-plugin-activation.php:2354
+msgid "Source"
+msgstr ""
+
+#: class-tgm-plugin-activation.php:2355
+msgid "Type"
+msgstr ""
+
+#: class-tgm-plugin-activation.php:2359
+msgid "Version"
+msgstr ""
+
+#: class-tgm-plugin-activation.php:2363
+msgid "Status"
+msgstr ""
+
+#: class-tgm-plugin-activation.php:2384
+#, php-format
+msgctxt "%2$s = plugin name in screen reader markup"
+msgid "Install %2$s"
+msgstr ""
+
+#: class-tgm-plugin-activation.php:2390
+#, php-format
+msgctxt "%2$s = plugin name in screen reader markup"
+msgid "Update %2$s"
+msgstr ""
+
+#: class-tgm-plugin-activation.php:2396
+#, php-format
+msgctxt "%2$s = plugin name in screen reader markup"
+msgid "Activate %2$s"
+msgstr ""
+
+#: class-tgm-plugin-activation.php:2467
+msgid "Upgrade message from the plugin author:"
+msgstr ""
+
+#: class-tgm-plugin-activation.php:2487
+msgid "Install"
+msgstr ""
+
+#: class-tgm-plugin-activation.php:2493
+msgid "Update"
+msgstr ""
+
+#: class-tgm-plugin-activation.php:2496
+msgid "Activate"
+msgstr ""
+
+#: class-tgm-plugin-activation.php:2555
+msgid "No plugins are available to be installed at this time."
+msgstr ""
+
+#: class-tgm-plugin-activation.php:2557
+msgid "No plugins are available to be updated at this time."
+msgstr ""
+
+#: class-tgm-plugin-activation.php:2680
+msgid "No plugins are available to be activated at this time."
+msgstr ""
+
+#: class-tgm-plugin-activation.php:2871
+msgid "Plugin activation failed."
+msgstr ""
+
+#: class-tgm-plugin-activation.php:3207
+#, php-format
+msgid "Updating Plugin %1$s (%2$d/%3$d)"
+msgstr ""
+
+#: class-tgm-plugin-activation.php:3211
+#, php-format
+msgid "An error occurred while installing %1$s: <strong>%2$s</strong>."
+msgstr ""
+
+#: class-tgm-plugin-activation.php:3212
+#, php-format
+msgid "The installation of %1$s failed."
+msgstr ""
+
+#: class-tgm-plugin-activation.php:3216
+msgid ""
+"The installation and activation process is starting. This process may take a "
+"while on some hosts, so please be patient."
+msgstr ""
+
+#: class-tgm-plugin-activation.php:3217
+#, php-format
+msgid "%1$s installed and activated successfully."
+msgstr ""
+
+#: class-tgm-plugin-activation.php:3217 class-tgm-plugin-activation.php:3224
+msgid "Show Details"
+msgstr ""
+
+#: class-tgm-plugin-activation.php:3217 class-tgm-plugin-activation.php:3224
+msgid "Hide Details"
+msgstr ""
+
+#: class-tgm-plugin-activation.php:3218
+msgid "All installations and activations have been completed."
+msgstr ""
+
+#: class-tgm-plugin-activation.php:3219
+#, php-format
+msgid "Installing and Activating Plugin %1$s (%2$d/%3$d)"
+msgstr ""
+
+#: class-tgm-plugin-activation.php:3223
+msgid ""
+"The installation process is starting. This process may take a while on some "
+"hosts, so please be patient."
+msgstr ""
+
+#: class-tgm-plugin-activation.php:3224
+#, php-format
+msgid "%1$s installed successfully."
+msgstr ""
+
+#: class-tgm-plugin-activation.php:3225
+msgid "All installations have been completed."
+msgstr ""
+
+#: class-tgm-plugin-activation.php:3226
+#, php-format
+msgid "Installing Plugin %1$s (%2$d/%3$d)"
+msgstr ""


### PR DESCRIPTION
Closes #192, #350, #351 

The commits have been set up to facilitate easier code review as these are quite significant changes. Please see the individual commit messages for detailed information on what I've changed, how and why.

#### Functional highlights:
* Updating can now be done from the TGMPA screen, both on individual plugins as well as in bulk - this will take into account WP repo updates as well as updates for plugins which are bundled or come from external sources where a minimum version is set which is higher than the current version.
* Users will be notified of available updates.
* TGMPA screen now has four views: _all_, _to install_, _update available_ and _to activate_
* TGMPA screen now has - on selected views - an extra column showing relevant plugin version information.
* TGMPA screen status column will show both install/activate as well as update status (cumulative).
* If a plugin **_requires_** a certain minimum version of a plugin and the currently installed version does not comply, activation will be blocked until the user has upgraded. If the plugin is already active, it will *not* be deactivated however.
	* If the required plugin version itself requires a higher WP version than the currently installed WP, upgrade will be blocked
* The plugin action links on the WP native plugins page will reflect this too - including disabling deactivation if `force_activation` is `true` for a plugin

Branch has been tested, but further testing is very welcome /cc @duckzland @swiderski
Testing on setups with non-direct filesystem access would be much appreciated (should work, but rather would get it confirmed).

Should work with WP 3.7 and higher.

Props [Zauan/Hogash Studio], [Christian], [Franklin Gitonga], [Jason Xie], [swiderski] for the inspiration.

#### Screenshots:
![screenshot](http://snag.gy/pCTTN.jpg)
![screenshot](http://snag.gy/0HXRK.jpg)