### PR TITLE
Document the `tgmpa_load` filter and reverse its logic ...

### DIFF
--- a/class-tgm-plugin-activation.php
+++ b/class-tgm-plugin-activation.php
@@ -274,7 +274,14 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
 		 */
 		public function init() {
 
-			if ( apply_filters( 'tgmpa_load', ! is_admin() ) ) {
+			/**
+			 * By default TGMPA only loads on the WP back-end. Using this filter you can overrule that behaviour.
+			 *
+			 * @since 2.5.0
+			 *
+			 * @param bool $load Whether or not TGMPA should load. Defaults to the return of `is_admin()`.
+			 */
+			if ( true !== apply_filters( 'tgmpa_load', is_admin() ) ) {
 				return;
 			}
 


### PR DESCRIPTION
...to make it more logical in use.

Previously `false` had to be returned for TGMPA to load which would be confusing for people implementing it.

This shouldn't cause issues for "existing implementations" as the filter has only been introduced a week ago and I doubt there are any existing implementations yet.