### PR TITLE
Deprecate the 'tgmpa_admin_menu_use_add_theme_page' filter.

### DIFF
--- a/class-tgm-plugin-activation.php
+++ b/class-tgm-plugin-activation.php
@@ -580,7 +580,11 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
 		 * @param array $args Menu item configuration.
 		 */
 		protected function add_admin_menu( array $args ) {
-			if ( apply_filters( 'tgmpa_admin_menu_use_add_theme_page', true ) ) {
+			if ( has_filter( 'tgmpa_admin_menu_use_add_theme_page' ) ) {
+				_deprecated_function( 'The "tgmpa_admin_menu_use_add_theme_page" filter', '2.5.0', esc_html__( 'Set the parent_slug config variable instead.', 'tgmpa' ) );
+			}
+
+			if ( 'themes.php' === $this->parent_slug ) {
 				$this->page_hook = call_user_func( 'add_theme_page', $args['page_title'], $args['menu_title'], $args['capability'], $args['menu_slug'], $args['function'] );
 
 			} else {


### PR DESCRIPTION
This filter has become superfluous now people can set a `parent_slug` through the config array.

Also, the logic of which admin_menu call to use didn't account for that properly and now does.