### PR TITLE
Rename a filter for consistency.

### DIFF
--- a/class-tgm-plugin-activation.php
+++ b/class-tgm-plugin-activation.php
@@ -1992,7 +1992,7 @@ if ( ! class_exists( 'TGMPA_List_Table' ) ) {
 				$this->view_context = sanitize_key( $_REQUEST['plugin_status'] );
 			}
 
-			add_filter( 'tgmpa_plugin_table_items', array( $this, 'sort_table_items' ) );
+			add_filter( 'tgmpa_table_data_items', array( $this, 'sort_table_items' ) );
 		}
 
 		/**
@@ -2792,7 +2792,7 @@ if ( ! class_exists( 'TGMPA_List_Table' ) ) {
 			}
 
 			// Store all of our plugin data into $items array so WP_List_Table can use it.
-			$this->items = apply_filters( 'tgmpa_plugin_table_items', $this->_gather_plugin_data() );
+			$this->items = apply_filters( 'tgmpa_table_data_items', $this->_gather_plugin_data() );
 
 		}
 


### PR DESCRIPTION
An already existing filter on individual items is called `tgmpa_table_data_item`. It would therefore be more logical for this filter on the array of items to be called `tgmpa_table_data_items` instead of `tgmpa_plugin_table_items`.

This shouldn't give any issues with "existing implementations" as the filter was only introduced about a week ago.