### PR TITLE
Minor automated testing tweaks.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,10 @@ matrix:
         # aliased to a recent 5.6.x version
         - php: '5.6'
           env: SNIFF=1
-        # aliased to a recent 7.x version
+        # aliased to a recent 7.0.x version
         - php: '7.0'
+        # aliased to a recent 7.1.x version
+        - php: '7.1'
         # aliased to a recent hhvm version
         - php: 'hhvm'
 
@@ -32,21 +34,18 @@ matrix:
 
 before_script:
   - export PHPCS_DIR=/tmp/phpcs
-  - export WPCS_DIR=/tmp/wpcs
+  - export SNIFFS_DIR=/tmp/sniffs
   # Install CodeSniffer for WordPress Coding Standards checks.
   - if [[ "$SNIFF" == "1" ]]; then git clone -b master --depth 1 https://github.com/squizlabs/PHP_CodeSniffer.git $PHPCS_DIR; fi
   # Install WordPress Coding Standards.
-  - if [[ "$SNIFF" == "1" ]]; then git clone -b master --depth 1 https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards.git $WPCS_DIR; fi
-  # Hop into CodeSniffer directory.
-  - if [[ "$SNIFF" == "1" ]]; then cd $PHPCS_DIR; fi
+  - if [[ "$SNIFF" == "1" ]]; then git clone -b master --depth 1 https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards.git $SNIFFS_DIR; fi
+  # Install PHP Compatibility sniffs.
+  - if [[ "$SNIFF" == "1" ]]; then git clone -b master --depth 1 https://github.com/wimg/PHPCompatibility.git $SNIFFS_DIR/PHPCompatibility; fi
   # Set install path for WordPress Coding Standards.
   # @link https://github.com/squizlabs/PHP_CodeSniffer/blob/4237c2fc98cc838730b76ee9cee316f99286a2a7/CodeSniffer.php#L1941
-  - if [[ "$SNIFF" == "1" ]]; then $PHPCS_DIR/scripts/phpcs --config-set installed_paths $WPCS_DIR; fi
-  # Hop back into project dir.
-  - if [[ "$SNIFF" == "1" ]]; then cd $TRAVIS_BUILD_DIR; fi
+  - if [[ "$SNIFF" == "1" ]]; then $PHPCS_DIR/scripts/phpcs --config-set installed_paths $SNIFFS_DIR; fi
   # After CodeSniffer install you should refresh your path.
   - if [[ "$SNIFF" == "1" ]]; then phpenv rehash; fi
-
 
 # Run test script commands.
 # All commands must exit with code 0 on success. Anything else is considered failure.

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -5,6 +5,12 @@
 	<file>example.php</file>
 	<arg name="report" value="full"/>
 	<arg value="spn"/>
+
+	<!-- ##### Sniffs for PHP cross-version compatibility ##### -->
+	<config name="testVersion" value="5.2-99.0"/>
+	<rule ref="PHPCompatibility"/>
+
+	<!-- ##### Code style ##### -->
 	<rule ref="WordPress">
 		<exclude name="WordPress.VIP" />
 	</rule>


### PR DESCRIPTION
- Add PHP 7.1 to the travis test matrix as it will be released soon.
- Add sniffing for cross-PHP version compatibility to the PHPCS ruleset with a preset testVersion so we receive the messages for the right PHP versions.
