### PR TITLE
Change behaviour if ABSPATH not found

### DIFF
--- a/class-tgm-plugin-activation.php
+++ b/class-tgm-plugin-activation.php
@@ -34,7 +34,7 @@
 
 // Exit if accessed directly.
 if ( ! defined( 'ABSPATH' ) ) {
-	exit;
+	return;
 }
 
 if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {


### PR DESCRIPTION
`exit`-ing kills command line scripts (like `phpunit` or `phpcs`) completely (and silently, grrrr), instead of just ignoring the rest of the TGMPA file, which is what `return` does.

See #594.

Aside: I'd really like to see this go out as a hotfix, even if some of the other developments since the last release are not ready.