### PR TITLE
Fix the example 'source' path to work with child themes

### DIFF
--- a/example.php
+++ b/example.php
@@ -63,7 +63,7 @@ function my_theme_register_required_plugins() {
 		array(
 			'name'               => 'TGM Example Plugin', // The plugin name.
 			'slug'               => 'tgm-example-plugin', // The plugin slug (typically the folder name).
-			'source'             => get_stylesheet_directory() . '/lib/plugins/tgm-example-plugin.zip', // The plugin source.
+			'source'             => get_template_directory() . '/lib/plugins/tgm-example-plugin.zip', // The plugin source.
 			'required'           => true, // If false, the plugin is only 'recommended' instead of required.
 			'version'            => '', // E.g. 1.0.0. If set, the active plugin must be this version or higher. If the plugin version is higher than the plugin version installed, the user will be notified to update the plugin.
 			'force_activation'   => false, // If true, plugin is activated upon theme activation and cannot be deactivated until theme switch.


### PR DESCRIPTION
By using the [get_template_directory()](https://codex.wordpress.org/Function_Reference/get_template_directory) function, it retrieves the absolute path to the directory of the current theme; and if a child theme is being used, the absolute path to the parent theme directory will be returned.

I think it makes more sense to use this method in the example script in case theme developers are just copying this without testing if it works for child themes. I would imagine this gets used for more parent themes than child themes anyway.