### PR TITLE
Build/CS: various tweaks to Travis script/PHPCS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@
 # Use new container based environment
 sudo: false
 
+dist: trusty
+
 # Declare project language.
 # @link http://about.travis-ci.org/docs/user/languages/php/
 language: php
@@ -17,13 +19,14 @@ matrix:
         # Current $required_php_version for WordPress: 5.2.4
         # aliased to 5.2.17
         - php: '5.2'
+          dist: precise
         # aliased to a recent 5.4.x version
         - php: '5.4'
         # aliased to a recent 5.6.x version
         - php: '5.6'
-          env: SNIFF=1
         # aliased to a recent 7.0.x version
         - php: '7.0'
+          env: SNIFF=1
         # aliased to a recent 7.1.x version
         - php: '7.1'
         # aliased to a recent hhvm version
@@ -34,17 +37,17 @@ matrix:
 
 before_script:
   - export PHPCS_DIR=/tmp/phpcs
-  - export SNIFFS_DIR=/tmp/sniffs
+  - export WPCS_DIR=/tmp/wpcs
+  - export PHPCOMPAT_DIR=/tmp/phpcompatibility
   # Install CodeSniffer for WordPress Coding Standards checks.
-  # @TODO Change branch back to master once WPCS + PHPCompatibility are compatible with PHPCS 3.x.
-  - if [[ "$SNIFF" == "1" ]]; then git clone -b 2.9 --depth 1 https://github.com/squizlabs/PHP_CodeSniffer.git $PHPCS_DIR; fi
+  - if [[ "$SNIFF" == "1" ]]; then git clone -b master --depth 1 https://github.com/squizlabs/PHP_CodeSniffer.git $PHPCS_DIR; fi
   # Install WordPress Coding Standards.
-  - if [[ "$SNIFF" == "1" ]]; then git clone -b master --depth 1 https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards.git $SNIFFS_DIR; fi
+  - if [[ "$SNIFF" == "1" ]]; then git clone -b master --depth 1 https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards.git $WPCS_DIR; fi
   # Install PHP Compatibility sniffs.
-  - if [[ "$SNIFF" == "1" ]]; then git clone -b master --depth 1 https://github.com/wimg/PHPCompatibility.git $SNIFFS_DIR/PHPCompatibility; fi
+  - if [[ "$SNIFF" == "1" ]]; then git clone -b master --depth 1 https://github.com/wimg/PHPCompatibility.git $PHPCOMPAT_DIR; fi
   # Set install path for WordPress Coding Standards.
   # @link https://github.com/squizlabs/PHP_CodeSniffer/blob/4237c2fc98cc838730b76ee9cee316f99286a2a7/CodeSniffer.php#L1941
-  - if [[ "$SNIFF" == "1" ]]; then $PHPCS_DIR/scripts/phpcs --config-set installed_paths $SNIFFS_DIR; fi
+  - if [[ "$SNIFF" == "1" ]]; then $PHPCS_DIR/bin/phpcs --config-set installed_paths $WPCS_DIR,$PHPCOMPAT_DIR; fi
   # After CodeSniffer install you should refresh your path.
   - if [[ "$SNIFF" == "1" ]]; then phpenv rehash; fi
 
@@ -57,7 +60,7 @@ script:
   # @link https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
   # @link https://github.com/squizlabs/PHP_CodeSniffer
   # All of the usual config flags are held in phpcs.xml
-  - if [[ "$SNIFF" == "1" ]]; then $PHPCS_DIR/scripts/phpcs; fi
+  - if [[ "$SNIFF" == "1" ]]; then $PHPCS_DIR/bin/phpcs --runtime-set ignore_warnings_on_exit 1; fi
 
 notifications:
   email: false

--- a/class-tgm-plugin-activation.php
+++ b/class-tgm-plugin-activation.php
@@ -940,7 +940,7 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
 				if ( false === $this->activate_single_plugin( $this->plugins[ $slug ]['file_path'], $slug ) ) {
 					return true; // Finish execution of the function early as we encountered an error.
 				}
-			} // End if().
+			}
 
 			return false;
 		}
@@ -1114,7 +1114,7 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
 					// Simpler message layout for use on the plugin install page.
 					echo '<p>', sprintf( esc_html( $this->strings['plugin_needs_higher_version'] ), esc_html( $this->plugins[ $slug ]['name'] ) ), '</p>';
 				}
-			} // End if().
+			}
 
 			return true;
 		}
@@ -1198,8 +1198,8 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
 							$total_required_action_count++;
 						}
 					}
-				} // End if().
-			} // End foreach().
+				}
+			}
 			unset( $slug, $plugin );
 
 			// If we have notices to display, we move forward.
@@ -1249,11 +1249,11 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
 					unset( $type, $plugin_group, $linked_plugins, $count, $last_plugin, $imploded );
 
 					$rendered .= $this->create_user_action_links_for_notice( $install_link_count, $update_link_count, $activate_link_count, $line_template );
-				} // End if().
+				}
 
 				// Register the nag messages and prepare them to be processed.
 				add_settings_error( 'tgmpa', 'tgmpa', $rendered, $this->get_admin_notice_class() );
-			} // End if().
+			}
 
 			// Admin options pages already output settings_errors, so this is to avoid duplication.
 			if ( 'options-general' !== $GLOBALS['current_screen']->parent_base ) {
@@ -2160,7 +2160,7 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
 	} else {
 		add_action( 'plugins_loaded', 'load_tgm_plugin_activation' );
 	}
-} // End if().
+}
 
 if ( ! function_exists( 'tgmpa' ) ) {
 	/**
@@ -2198,7 +2198,7 @@ if ( ! function_exists( 'tgmpa' ) ) {
 			call_user_func( array( $instance, 'config' ), $config );
 		}
 	}
-} // End if().
+}
 
 /**
  * WP_List_Table isn't always available. If it isn't available,
@@ -2555,7 +2555,7 @@ if ( ! class_exists( 'TGMPA_List_Table' ) ) {
 						sprintf( $text, number_format_i18n( $count ) )
 					);
 				}
-			} // End foreach().
+			}
 
 			return $status_links;
 		}
@@ -3042,7 +3042,7 @@ if ( ! class_exists( 'TGMPA_List_Table' ) ) {
 				echo '</div></div>';
 
 				return true;
-			} // End if().
+			}
 
 			// Bulk activation process.
 			if ( 'tgmpa-bulk-activate' === $this->current_action() ) {
@@ -3111,7 +3111,7 @@ if ( ! class_exists( 'TGMPA_List_Table' ) ) {
 				unset( $_POST ); // Reset the $_POST variable in case user wants to perform one action after another.
 
 				return true;
-			} // End if().
+			}
 
 			return false;
 		}
@@ -3156,7 +3156,7 @@ if ( ! class_exists( 'TGMPA_List_Table' ) ) {
 			return $this->tgmpa->_get_plugin_data_from_name( $name, $data );
 		}
 	}
-} // End if().
+}
 
 
 if ( ! class_exists( 'TGM_Bulk_Installer' ) ) {
@@ -3439,7 +3439,7 @@ if ( ! function_exists( 'tgmpa_load_bulk_installer' ) ) {
 							if ( false === $result ) {
 								break;
 							}
-						} // End foreach().
+						}
 
 						$this->maintenance_mode( false );
 
@@ -3546,7 +3546,7 @@ if ( ! function_exists( 'tgmpa_load_bulk_installer' ) ) {
 						return $bool;
 					}
 				}
-			} // End if().
+			}
 
 			if ( ! class_exists( 'TGMPA_Bulk_Installer_Skin' ) ) {
 
@@ -3780,10 +3780,10 @@ if ( ! function_exists( 'tgmpa_load_bulk_installer' ) ) {
 						$this->i++;
 					}
 				}
-			} // End if().
-		} // End if().
-	} // End if().
-} // End if().
+			}
+		}
+	}
+}
 
 if ( ! class_exists( 'TGMPA_Utils' ) ) {
 
@@ -3911,4 +3911,4 @@ if ( ! class_exists( 'TGMPA_Utils' ) ) {
 			return false;
 		}
 	} // End of class TGMPA_Utils
-}  // End if().
+}

--- a/class-tgm-plugin-activation.php
+++ b/class-tgm-plugin-activation.php
@@ -654,7 +654,7 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
 				wp_enqueue_style( 'plugin-install' );
 
 				global $tab, $body_id;
-				$body_id = 'plugin-information';
+				$body_id = 'plugin-information'; // WPCS: override ok, prefix ok.
 				$tab     = 'plugin-information'; // WPCS: override ok.
 
 				install_plugin_information();
@@ -751,7 +751,7 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
 		 */
 		public function install_plugins_page() {
 			// Store new instance of plugin table in object.
-			$plugin_table = new TGMPA_List_Table;
+			$plugin_table = new TGMPA_List_Table();
 
 			// Return early if processing a plugin installation action.
 			if ( ( ( 'tgmpa-bulk-install' === $plugin_table->current_action() || 'tgmpa-bulk-update' === $plugin_table->current_action() ) && $plugin_table->process_bulk_actions() ) || $this->do_plugin_install() ) {
@@ -956,14 +956,14 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
 			$repo_updates = get_site_transient( 'update_plugins' );
 
 			if ( ! is_object( $repo_updates ) ) {
-				$repo_updates = new stdClass;
+				$repo_updates = new stdClass();
 			}
 
 			foreach ( $plugins as $slug => $plugin ) {
 				$file_path = $plugin['file_path'];
 
 				if ( empty( $repo_updates->response[ $file_path ] ) ) {
-					$repo_updates->response[ $file_path ] = new stdClass;
+					$repo_updates->response[ $file_path ] = new stdClass();
 				}
 
 				// We only really need to set package, but let's do all we can in case WP changes something.
@@ -3459,12 +3459,16 @@ if ( ! function_exists( 'tgmpa_load_bulk_installer' ) ) {
 						 *     @type array  $packages Array of plugin, theme, or core packages to update.
 						 * }
 						 */
-						do_action( 'upgrader_process_complete', $this, array(
-							'action'  => 'install', // [TGMPA + ] adjusted.
-							'type'    => 'plugin',
-							'bulk'    => true,
-							'plugins' => $plugins,
-						) );
+						do_action( // WPCS: prefix OK.
+							'upgrader_process_complete',
+							$this,
+							array(
+								'action'  => 'install', // [TGMPA + ] adjusted.
+								'type'    => 'plugin',
+								'bulk'    => true,
+								'plugins' => $plugins,
+							)
+						);
 
 						$this->skin->bulk_footer();
 

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -14,19 +14,41 @@
 
 	<!-- ##### Code style ##### -->
 	<rule ref="WordPress">
-		<exclude name="WordPress.VIP" />
+		<exclude name="WordPress.VIP"/>
 	</rule>
 
 	<rule ref="WordPress.WP.I18n">
 		<properties>
 			<!-- TGMPA itself uses `tgmpa`, the example file uses `theme-slug`. -->
-			<property name="text_domain" type="array" value="tgmpa,theme-slug" />
+			<property name="text_domain" type="array" value="tgmpa,theme-slug"/>
 		</properties>
 	</rule>
 
+	<rule ref="WordPress.NamingConventions.PrefixAllGlobals">
+		<properties>
+			<!--
+				* Classes are prefixed with `TGM`.
+				* Everything else in the global namespace with `tgmpa`.
+				* The example file use the example prefix `my_theme`.
+			-->
+			<property name="prefixes" type="array" value="tgmpa,tgm,my_theme,load_tgm" />
+		</properties>
+	</rule>
+
+	<!-- The value of the below properties should be in-line with the "requires at least" version in the readme. -->
+	<rule ref="WordPress.WP.DeprecatedClasses">
+		<properties>
+			<property name="minimum_supported_version" value="3.7"/>
+		</properties>
+	</rule>
 	<rule ref="WordPress.WP.DeprecatedFunctions">
 		<properties>
-			<property name="minimum_supported_version" value="3.7" />
+			<property name="minimum_supported_version" value="3.7"/>
+		</properties>
+	</rule>
+	<rule ref="WordPress.WP.DeprecatedParameters">
+		<properties>
+			<property name="minimum_supported_version" value="3.7"/>
 		</properties>
 	</rule>
 

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -6,7 +6,7 @@
 	<file>example.php</file>
 
 	<arg name="report" value="full"/>
-	<arg value="spn"/>
+	<arg value="sp"/>
 
 	<!-- ##### Sniffs for PHP cross-version compatibility ##### -->
 	<config name="testVersion" value="5.2-99.0"/>


### PR DESCRIPTION
Travis:
* Run PHP 5.2 on `precise`. See: https://blog.travis-ci.com/2017-07-11-trusty-as-default-linux-is-coming
* Start using PHPCS 3.x :tada:
* Run the sniffs on PHP 7.0
* Make the necessary adjustments to account for the directory layout change in PHPCompatibility
* Don't hide PHPCS warnings, but don't break the builds for them either.

PHPCS/WPCS:
* Enable the prefix check for globals by adding the required custom property.
* Set the minimum supported WP version to be in line with the "Requires at least" version in the readme.

Code:
* Minor codestyle update for WPCS 0.12.0 (0.13.0) compliance
* Remove end comments which are no longer required.