### PR TITLE
Check if did_action function exists

### DIFF
--- a/class-tgm-plugin-activation.php
+++ b/class-tgm-plugin-activation.php
@@ -2154,11 +2154,15 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
 			$GLOBALS['tgmpa'] = TGM_Plugin_Activation::get_instance();
 		}
 	}
+	
+	if( function_exists( 'did_action' ) ) {
 
-	if ( did_action( 'plugins_loaded' ) ) {
-		load_tgm_plugin_activation();
-	} else {
-		add_action( 'plugins_loaded', 'load_tgm_plugin_activation' );
+		if ( did_action( 'plugins_loaded' ) ) {
+			load_tgm_plugin_activation();
+		} else {
+			add_action( 'plugins_loaded', 'load_tgm_plugin_activation' );
+		}
+		
 	}
 }
 


### PR DESCRIPTION
This is an edge case but when using frameworks such as Themosis or Bedrock, these work by loading up dependancies at root level before Wordpress is instantiated, along with any composer autoload files - so functions like `did_action` in your autoload file do not exist yet, and throw a fatal error.

The way these frameworks work is to load up instantiation of dependant functions and processes through `ServiceProviders` on `boot`, and it here that we would call `load_tgm_plugin_activation`, and not in the composer autoload.

See below ServiceProvider we are using for TGMPA integration with our framework which works nicely when this pull request is applied:

https://github.com/wp-kit/tgmpa-integration/blob/master/src/Tgmpa/TgmpaServiceProvider.php#L22