### PR TITLE
Travis: run the build tests against PHP 7.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,8 +27,8 @@ matrix:
         # aliased to a recent 7.0.x version
         - php: '7.0'
           env: SNIFF=1
-        # aliased to a recent 7.1.x version
-        - php: '7.1'
+        # aliased to a recent 7.2.x version
+        - php: '7.2'
         # aliased to a recent hhvm version
         - php: 'hhvm'
 


### PR DESCRIPTION
The new Trusty images as per Sept 7 include an image for PHP 7.2 (even though it hasn't been released yet) and nightly is now PHP 7.3-dev.