### PR TITLE
Ensure composer.lock stays out of version control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
-# folders and files to be ignored by git
-phpcs.xml
+/vendor/
+/composer.lock
+/phpcs.xml
+/.phpcs.xml


### PR DESCRIPTION
This is a library package, not an application.

See https://blog.martinhujer.cz/17-tips-for-using-composer-efficiently/#tip-%236%3A-put-%60composer.lock%60-into-%60.gitignore%60-in-libraries