### PR TITLE
Use SPDX License List 3.0 identifier

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "description": "TGM Plugin Activation is a PHP library that allows you to easily require or recommend plugins for your WordPress themes (and plugins).",
   "homepage": "http://tgmpluginactivation.com",
   "keywords": ["wordpress","plugins", "theme", "library", "activation"],
-  "license": "GPL-2.0+",
+  "license": "GPL-2.0-or-later",
   "authors": [
     {
       "name": "Thomas Griffin",


### PR DESCRIPTION
See https://spdx.org/news/news/2018/01/license-list-30-released

Composer 1.6 considers `GPL-2.0+` to be invalid.