### PR TITLE
Travis: stop build testing against HHVM

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,11 +29,6 @@ matrix:
           env: SNIFF=1
         # aliased to a recent 7.2.x version
         - php: '7.2'
-        # aliased to a recent hhvm version
-        - php: 'hhvm'
-
-    allow_failures:
-        - php: 'hhvm'
 
 before_script:
   - export PHPCS_DIR=/tmp/phpcs


### PR DESCRIPTION
At some point in time, PHP was lagging behind and HHVM seemed like the future. What with PHP 7 being released and doing incredibly well, that time has passed and the popularity of HHVM is now marginal.

Having said, I'm suggesting we stop build testing TGMPA on HHVM.