### PR TITLE
Travis: speed up build times by disabling Xdebug

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,8 @@ matrix:
         - php: 'hhvm'
 
 before_script:
+  # Speed up build time by disabling Xdebug when its not needed.
+  - phpenv config-rm xdebug.ini
   - export PHPCS_DIR=/tmp/phpcs
   - export WPCS_DIR=/tmp/wpcs
   - export PHPCOMPAT_DIR=/tmp/phpcompatibility


### PR DESCRIPTION
As suggested by @johnbillion in https://johnblackbourn.com/reducing-travis-ci-build-times-for-wordpress-projects/ , when not creating code coverage reports, Xdebug is not needed and disabling it will speed up the build.

While the builds run for TGMPA are still very small, once unit tests start being added, this will make a difference. In the mean time, it doesn't hurt having this directive in the script.