### PR TITLE
Travis/Build: validate the composer.json file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,6 +61,9 @@ script:
   # @link https://github.com/squizlabs/PHP_CodeSniffer
   # All of the usual config flags are held in phpcs.xml
   - if [[ "$SNIFF" == "1" ]]; then $PHPCS_DIR/bin/phpcs --runtime-set ignore_warnings_on_exit 1; fi
+  # Validate the composer.json file.
+  # @link https://getcomposer.org/doc/03-cli.md#validate
+  - if [[ $TRAVIS_PHP_VERSION != "5.2" ]]; then composer validate --no-check-all; fi
 
 notifications:
   email: false


### PR DESCRIPTION
As discussed in #715.

Validate the `composer.json` file on each build.
Ref: https://getcomposer.org/doc/03-cli.md#validate

Notes:
* This check has not been restricted to a specific PHP version as there may be different versions of Composer being run on different Travis PHP images, so validating the file once against each PHP/Composer combi should make sure the file is properly validated.
* `--strict` checking is disabled with reason. As of Composer 1.6.0, the SPDX license identifiers v3.0 for GPL/LGPL/AGPL are supported and the old license identifiers are deprecated.
    So using the "new" license identifier would fail the validation for Composer < 1.6.0, using the old license identifier would fail the validation for Composer 1.6.0+. By ignoring warnings, this issue is bypassed.

Refs:
* https://github.com/composer/composer/releases/tag/1.6.0
* https://spdx.org/news/news/2018/01/license-list-30-released