### PR TITLE
Add has_notices on plugin level

### DIFF
--- a/class-tgm-plugin-activation.php
+++ b/class-tgm-plugin-activation.php
@@ -1153,7 +1153,6 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
 				if ( $this->is_plugin_active( $slug ) && false === $this->does_plugin_have_update( $slug ) ) {
 					continue;
 				}
-				
 				if ( false === $plugin['has_notices'] ) {
 					continue;
 				}

--- a/class-tgm-plugin-activation.php
+++ b/class-tgm-plugin-activation.php
@@ -1153,6 +1153,10 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
 				if ( $this->is_plugin_active( $slug ) && false === $this->does_plugin_have_update( $slug ) ) {
 					continue;
 				}
+				
+				if(isset($plugin['has_notices']) && false === $plugin['has_notices']){
+					continue;
+				}
 
 				if ( ! $this->is_plugin_installed( $slug ) ) {
 					if ( current_user_can( 'install_plugins' ) ) {

--- a/class-tgm-plugin-activation.php
+++ b/class-tgm-plugin-activation.php
@@ -1154,7 +1154,7 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
 					continue;
 				}
 				
-				if(isset($plugin['has_notices']) && false === $plugin['has_notices']){
+				if(false === $plugin['has_notices']){
 					continue;
 				}
 
@@ -1410,6 +1410,7 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
 				'force_deactivation' => false,   // Boolean.
 				'external_url'       => '',      // String.
 				'is_callable'        => '',      // String|Array.
+				'has_notices'        => true,    // Boolean.
 			);
 
 			// Prepare the received data.
@@ -1424,6 +1425,7 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
 			$plugin['required']           = TGMPA_Utils::validate_bool( $plugin['required'] );
 			$plugin['force_activation']   = TGMPA_Utils::validate_bool( $plugin['force_activation'] );
 			$plugin['force_deactivation'] = TGMPA_Utils::validate_bool( $plugin['force_deactivation'] );
+			$plugin['has_notices']        = TGMPA_Utils::validate_bool( $plugin['has_notices'] );
 
 			// Enrich the received data.
 			$plugin['file_path']   = $this->_get_plugin_basename_from_slug( $plugin['slug'] );

--- a/class-tgm-plugin-activation.php
+++ b/class-tgm-plugin-activation.php
@@ -1154,7 +1154,7 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
 					continue;
 				}
 				
-				if(false === $plugin['has_notices']){
+				if ( false === $plugin['has_notices'] ) {
 					continue;
 				}
 

--- a/example.php
+++ b/example.php
@@ -70,6 +70,7 @@ function my_theme_register_required_plugins() {
 			'force_deactivation' => false, // If true, plugin is deactivated upon theme switch, useful for theme-specific plugins.
 			'external_url'       => '', // If set, overrides default API URL and points to an external URL.
 			'is_callable'        => '', // If set, this callable will be be checked for availability to determine if a plugin is active.
+			'has_notices'        => true, // If false, this plugin will not be listed in the administrator notices. Useful to hide notice for recommended plugins. Default true.
 		),
 
 		// This is an example of how to include a plugin from an arbitrary external source in your theme.


### PR DESCRIPTION
This PR sets the `has_notice` on plugin level so that we can disable the notices for recommended plugins if we need to. Fixes #748 

Usage 

		'bbpress'=> array(
			'name'      => 'bbPress',
			'slug'      => 'bbpress',
			'required'  => false,
			'force_activation'   => false,
			'has_notices' => false // This plugin will not be visible in the TGMPA notice
		),