### PR TITLE
QA/CS: update for new releases of dev dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,20 +33,8 @@ matrix:
 before_script:
   # Speed up build time by disabling Xdebug when its not needed.
   - phpenv config-rm xdebug.ini || echo 'No xdebug config.'
-  - export PHPCS_DIR=/tmp/phpcs
-  - export WPCS_DIR=/tmp/wpcs
-  - export PHPCOMPAT_DIR=/tmp/phpcompatibility
-  # Install CodeSniffer for WordPress Coding Standards checks.
-  - if [[ "$SNIFF" == "1" ]]; then git clone -b master --depth 1 https://github.com/squizlabs/PHP_CodeSniffer.git $PHPCS_DIR; fi
-  # Install WordPress Coding Standards.
-  - if [[ "$SNIFF" == "1" ]]; then git clone -b master --depth 1 https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards.git $WPCS_DIR; fi
-  # Install PHP Compatibility sniffs.
-  - if [[ "$SNIFF" == "1" ]]; then git clone -b master --depth 1 https://github.com/wimg/PHPCompatibility.git $PHPCOMPAT_DIR; fi
-  # Set install path for WordPress Coding Standards.
-  # @link https://github.com/squizlabs/PHP_CodeSniffer/blob/4237c2fc98cc838730b76ee9cee316f99286a2a7/CodeSniffer.php#L1941
-  - if [[ "$SNIFF" == "1" ]]; then $PHPCS_DIR/bin/phpcs --config-set installed_paths $WPCS_DIR,$PHPCOMPAT_DIR; fi
-  # After CodeSniffer install you should refresh your path.
-  - if [[ "$SNIFF" == "1" ]]; then phpenv rehash; fi
+  # Install CodeSniffer and external standards for the CS checks.
+  - if [[ "$SNIFF" == "1" ]]; then composer install --dev; fi
 
 # Run test script commands.
 # All commands must exit with code 0 on success. Anything else is considered failure.
@@ -57,7 +45,7 @@ script:
   # @link https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
   # @link https://github.com/squizlabs/PHP_CodeSniffer
   # All of the usual config flags are held in phpcs.xml
-  - if [[ "$SNIFF" == "1" ]]; then $PHPCS_DIR/bin/phpcs --runtime-set ignore_warnings_on_exit 1; fi
+  - if [[ "$SNIFF" == "1" ]]; then $(pwd)/vendor/bin/phpcs --runtime-set ignore_warnings_on_exit 1; fi
   # Validate the composer.json file.
   # @link https://getcomposer.org/doc/03-cli.md#validate
   - if [[ $TRAVIS_PHP_VERSION != "5.2" ]]; then composer validate --no-check-all; fi

--- a/composer.json
+++ b/composer.json
@@ -30,9 +30,8 @@
   },
   "require-dev": {
     "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3",
-    "squizlabs/php_codesniffer": "^3.2",
-    "wimg/php-compatibility": "^8.1",
-    "wp-coding-standards/wpcs": "~0.14.0"
+    "phpcompatibility/phpcompatibility-wp": "^1.0",
+    "wp-coding-standards/wpcs": "^1.0"
   },
   "autoload": {
     "files": ["class-tgm-plugin-activation.php"]

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -13,12 +13,12 @@
 	<rule ref="PHPCompatibility"/>
 
 	<!-- ##### Code style ##### -->
-	<rule ref="WordPress">
-		<exclude name="WordPress.VIP"/>
-
+	<rule ref="WordPress-Extra">
 		<!-- This is a conscious choice & known issue and will not be fixed until v 3.0 (if ever). -->
 		<exclude name="Generic.Files.OneClassPerFile"/>
 	</rule>
+
+	<rule ref="WordPress-Docs"/>
 
 	<!-- The value of the below config variable should be in-line with the
 		 "requires at least" version in the readme. -->


### PR DESCRIPTION
Composer:
* Update to use WPCS 1.0.0.
* Switch over from using `PHPCompatibility` to `PHPCompatibilityWP`.
* Remove `PHP_CodeSniffer` dependency as it's not *our* dependency, but a dependency of WPCS and PHPCompatibility.

PHPCS ruleset:
* Use `WordPress-Extra` + `WordPress-Docs` to maintain the same behaviour as before.

Travis:
* Use Composer to install the dev dependencies instead of git cloning them.