### PR TITLE
Update for PHPCompatibilityWP 2.0.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
   },
   "require-dev": {
     "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3",
-    "phpcompatibility/phpcompatibility-wp": "^1.0",
+    "phpcompatibility/phpcompatibility-wp": "^2.0",
     "wp-coding-standards/wpcs": "^1.0"
   },
   "autoload": {

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -10,7 +10,7 @@
 
 	<!-- ##### Sniffs for PHP cross-version compatibility ##### -->
 	<config name="testVersion" value="5.2-99.0"/>
-	<rule ref="PHPCompatibility"/>
+	<rule ref="PHPCompatibilityWP"/>
 
 	<!-- ##### Code style ##### -->
 	<rule ref="WordPress-Extra">


### PR DESCRIPTION
Update to use the newer version of [PHPCompatibilityWP as released today](https://github.com/PHPCompatibility/PHPCompatibilityWP/releases/tag/2.0.0).

Also: not sure why I didn't change the standard reference in the ruleset in #755, but that's fixed now (not that it really mattered as TGMPA doesn't use any of the WP provided backfills, but still).