### PR TITLE
Build/Travis: test builds against PHP 7.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,8 @@ matrix:
           env: SNIFF=1
         # aliased to a recent 7.2.x version
         - php: '7.2'
+        # aliased to a recent 7.3.x version
+        - php: '7.3'
 
 before_script:
   # Speed up build time by disabling Xdebug when its not needed.


### PR DESCRIPTION
Once PHP 7.3-beta came out, the `nightly` build on Travis became PHP 7.4-dev and builds haven't been tested against PHP 7.3 for months now.

Luckily, Travis has *finally* deemed it appropriate to set up a PHP 7.3 alias now RC3 is out, so I've added  PHP 7.3 to the matrix.