### PR TITLE
Build/Travis/Composer: various tweaks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,11 +33,11 @@ matrix:
         - php: '5.6'
         # aliased to a recent 7.0.x version
         - php: '7.0'
-          env: SNIFF=1
-        # aliased to a recent 7.2.x version
-        - php: '7.2'
         # aliased to a recent 7.3.x version
         - php: '7.3'
+          env: SNIFF=1
+        # 7.4.x/develop version
+        - php: "7.4snapshot"
 
 before_script:
   # Speed up build time by disabling Xdebug when its not needed.

--- a/composer.json
+++ b/composer.json
@@ -29,9 +29,9 @@
     "php": ">=5.2"
   },
   "require-dev": {
-    "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3",
+    "dealerdirect/phpcodesniffer-composer-installer": "^0.5.0",
     "phpcompatibility/phpcompatibility-wp": "^2.0",
-    "wp-coding-standards/wpcs": "^1.0"
+    "wp-coding-standards/wpcs": "^2.0"
   },
   "autoload": {
     "files": ["class-tgm-plugin-activation.php"]


### PR DESCRIPTION
### Travis:

* Add testing against PHP 7.4-develop.
* As PHP 7.3 has now been released, remove testing against PHP 7.2.
* Move the running of the sniffs to the PHP 7.3 build.

### Composer:
* Use WPCS 2.0+
* Use DealerDirect PHPCS installer 0.5+