### PR TITLE
CS: minor updates

### DIFF
--- a/class-tgm-plugin-activation.php
+++ b/class-tgm-plugin-activation.php
@@ -294,6 +294,7 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
 		 *               (Inside this class context, the __set() method if not used as there is direct access.)
 		 */
 		public function __set( $name, $value ) {
+			// phpcs:ignore Squiz.PHP.NonExecutableCode.ReturnNotRequired -- See explanation above.
 			return;
 		}
 
@@ -654,8 +655,11 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
 				wp_enqueue_style( 'plugin-install' );
 
 				global $tab, $body_id;
-				$body_id = 'plugin-information'; // WPCS: override ok, prefix ok.
-				$tab     = 'plugin-information'; // WPCS: override ok.
+				// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- WP requirement.
+				$body_id = 'plugin-information';
+
+				// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Overriding the WP global is the point.
+				$tab = 'plugin-information';
 
 				install_plugin_information();
 
@@ -1081,7 +1085,8 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
 					if ( ! $automatic ) {
 						// Make sure message doesn't display again if bulk activation is performed
 						// immediately after a single activation.
-						if ( ! isset( $_POST['action'] ) ) { // WPCS: CSRF OK.
+						// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Not using the superglobal.
+						if ( ! isset( $_POST['action'] ) ) {
 							echo '<div id="message" class="updated"><p>', esc_html( $this->strings['activated_successfully'] ), ' <strong>', esc_html( $this->plugins[ $slug ]['name'] ), '.</strong></p></div>';
 						}
 					} else {
@@ -1102,7 +1107,8 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
 				if ( ! $automatic ) {
 					// Make sure message doesn't display again if bulk activation is performed
 					// immediately after a single activation.
-					if ( ! isset( $_POST['action'] ) ) { // WPCS: CSRF OK.
+					// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Not using the superglobal.
+					if ( ! isset( $_POST['action'] ) ) {
 						echo '<div id="message" class="error"><p>',
 							sprintf(
 								esc_html( $this->strings['plugin_needs_higher_version'] ),
@@ -1405,7 +1411,7 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
 				'force_activation'   => false,   // Boolean.
 				'force_deactivation' => false,   // Boolean.
 				'external_url'       => '',      // String.
-				'is_callable'        => '',      // String|Array.
+				'is_callable'        => '',      // String or array.
 			);
 
 			// Prepare the received data.
@@ -1762,10 +1768,10 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
 			if ( 'update-core' === $screen->base ) {
 				// Core update screen.
 				return true;
-			} elseif ( 'plugins' === $screen->base && ! empty( $_POST['action'] ) ) { // WPCS: CSRF ok.
+			} elseif ( 'plugins' === $screen->base && ! empty( $_POST['action'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing
 				// Plugins bulk update screen.
 				return true;
-			} elseif ( 'update' === $screen->base && ! empty( $_POST['action'] ) ) { // WPCS: CSRF ok.
+			} elseif ( 'update' === $screen->base && ! empty( $_POST['action'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing
 				// Individual updates (ajax call).
 				return true;
 			}
@@ -3092,9 +3098,10 @@ if ( ! class_exists( 'TGMPA_List_Table' ) ) {
 					$last_plugin  = array_pop( $plugin_names ); // Pop off last name to prep for readability.
 					$imploded     = empty( $plugin_names ) ? $last_plugin : ( implode( ', ', $plugin_names ) . ' ' . esc_html_x( 'and', 'plugin A *and* plugin B', 'tgmpa' ) . ' ' . $last_plugin );
 
-					printf( // WPCS: xss ok.
+					printf(
 						'<div id="message" class="updated"><p>%1$s %2$s.</p></div>',
 						esc_html( _n( 'The following plugin was activated successfully:', 'The following plugins were activated successfully:', $count, 'tgmpa' ) ),
+						// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Pre-escaped via wrap_in_strong() method above.
 						$imploded
 					);
 
@@ -3459,7 +3466,8 @@ if ( ! function_exists( 'tgmpa_load_bulk_installer' ) ) {
 						 *     @type array  $packages Array of plugin, theme, or core packages to update.
 						 * }
 						 */
-						do_action( // WPCS: prefix OK.
+						do_action(
+							// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- Using WP core hook.
 							'upgrader_process_complete',
 							$this,
 							array(
@@ -3874,7 +3882,7 @@ if ( ! class_exists( 'TGMPA_Utils' ) ) {
 		 * @return bool
 		 */
 		protected static function emulate_filter_bool( $value ) {
-			// @codingStandardsIgnoreStart
+			// phpcs:disable WordPress.Arrays.ArrayDeclarationSpacing.ArrayItemNoNewLine
 			static $true  = array(
 				'1',
 				'true', 'True', 'TRUE',
@@ -3889,7 +3897,7 @@ if ( ! class_exists( 'TGMPA_Utils' ) ) {
 				'no', 'No', 'NO',
 				'off', 'Off', 'OFF',
 			);
-			// @codingStandardsIgnoreEnd
+			// phpcs:enable
 
 			if ( is_bool( $value ) ) {
 				return $value;

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -7,15 +7,19 @@
 
 	<arg name="report" value="full"/>
 	<arg value="sp"/>
+	<arg name="basepath" value="./"/>
 
 	<!-- ##### Sniffs for PHP cross-version compatibility ##### -->
-	<config name="testVersion" value="5.2-99.0"/>
+	<config name="testVersion" value="5.2-"/>
 	<rule ref="PHPCompatibilityWP"/>
 
 	<!-- ##### Code style ##### -->
 	<rule ref="WordPress-Extra">
 		<!-- This is a conscious choice & known issue and will not be fixed until v 3.0 (if ever). -->
-		<exclude name="Generic.Files.OneClassPerFile"/>
+		<exclude name="Generic.Files.OneObjectStructurePerFile"/>
+
+		<!-- Renaming these protected methods now would break BC. This needs to be left for a next major release. -->
+		<exclude name="PSR2.Methods.MethodDeclaration.Underscore"/>
 	</rule>
 
 	<rule ref="WordPress-Docs"/>
@@ -36,7 +40,7 @@
 			<!--
 				* Classes are prefixed with `TGM`.
 				* Everything else in the global namespace with `tgmpa`.
-				* The example file use the example prefix `my_theme`.
+				* The example file uses the example prefix `my_theme`.
 			-->
 			<property name="prefixes" type="array" value="tgmpa,tgm,my_theme,load_tgm" />
 		</properties>


### PR DESCRIPTION
* Minor ruleset updates:
    - Use PHPCS 3.x `basepath` directive.
    - Update the whitelisted "one OO object per file" sniff name. Sniff was swopped out in WPCS 2.0.
    - Whitelist underscore prefixed method names as renaming those now would break BC.
* Minor updates in the main TGMPA file:
    - Update the inline whitelist comments from WPCS native to PHPCS native style. The WPCS native whitelist comments were deprecated in WPCS 2.0.0.