### PR TITLE
Add option 'strict_versions' #779

### DIFF
--- a/class-tgm-plugin-activation.php
+++ b/class-tgm-plugin-activation.php
@@ -228,6 +228,15 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
 		public $strings = array();
 
 		/**
+		 * Holds 'strict versions' option
+		 *
+		 * @since 2.6.1
+		 *
+		 * @var boolean
+		 */
+		public $strict_versions = false;
+
+		/**
 		 * Holds the version of WordPress.
 		 *
 		 * @since 2.4.0
@@ -890,6 +899,11 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
 					$skin_args['plugin'] = $this->plugins[ $slug ]['file_path'];
 					$skin                = new Plugin_Upgrader_Skin( $skin_args );
 				} else {
+
+					if( $this->strict_versions === true && isset($this->plugins[ $slug ]['version']) && array_key_exists($this->plugins[ $slug ]['version'], $skin_args['api']->versions) ) {
+						$skin_args['api']->version = $this->plugins[ $slug ]['version'];
+					}
+
 					$skin = new Plugin_Installer_Skin( $skin_args );
 				}
 
@@ -1514,6 +1528,7 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
 				'is_automatic',
 				'message',
 				'strings',
+				'strict_versions'
 			);
 
 			foreach ( $keys as $key ) {
@@ -1655,7 +1670,16 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
 			$api    = $this->get_plugins_api( $slug );
 
 			if ( false !== $api && isset( $api->download_link ) ) {
-				$source = $api->download_link;
+
+				if($this->strict_versions === true){
+					$version = isset($this->plugins[$slug]['version']) ? $this->plugins[$slug]['version'] : '';
+					$versions = $api->versions;
+					$source = isset($versions[$version]) ? $versions[$version] : $api->download_link;
+				}
+				else{
+					$source = $api->download_link;
+				}
+
 			}
 
 			return $source;

--- a/example.php
+++ b/example.php
@@ -121,16 +121,17 @@ function my_theme_register_required_plugins() {
 	 * Only uncomment the strings in the config array if you want to customize the strings.
 	 */
 	$config = array(
-		'id'           => 'tgmpa',                 // Unique ID for hashing notices for multiple instances of TGMPA.
-		'default_path' => '',                      // Default absolute path to bundled plugins.
-		'menu'         => 'tgmpa-install-plugins', // Menu slug.
-		'parent_slug'  => 'themes.php',            // Parent menu slug.
-		'capability'   => 'edit_theme_options',    // Capability needed to view plugin install page, should be a capability associated with the parent menu used.
-		'has_notices'  => true,                    // Show admin notices or not.
-		'dismissable'  => true,                    // If false, a user cannot dismiss the nag message.
-		'dismiss_msg'  => '',                      // If 'dismissable' is false, this message will be output at top of nag.
-		'is_automatic' => false,                   // Automatically activate plugins after installation or not.
-		'message'      => '',                      // Message to output right before the plugins table.
+		'id'              => 'tgmpa',                 // Unique ID for hashing notices for multiple instances of TGMPA.
+		'default_path'    => '',                      // Default absolute path to bundled plugins.
+		'menu'            => 'tgmpa-install-plugins', // Menu slug.
+		'parent_slug'     => 'themes.php',            // Parent menu slug.
+		'capability'      => 'edit_theme_options',    // Capability needed to view plugin install page, should be a capability associated with the parent menu used.
+		'has_notices'     => true,                    // Show admin notices or not.
+		'dismissable'     => true,                    // If false, a user cannot dismiss the nag message.
+		'dismiss_msg'     => '',                      // If 'dismissable' is false, this message will be output at top of nag.
+		'is_automatic'    => false,                   // Automatically activate plugins after installation or not.
+		'message'         => '',                      // Message to output right before the plugins table.
+		'strict_versions' => false                    // Download of plugins will download the exactly version specified in version field
 
 		/*
 		'strings'      => array(


### PR DESCRIPTION
Add 'strict_versions' option to the TGM Plugin Activation. That allows to install the strict version of plugins defined in 'version' field of each plugin.