### PR TITLE
Exclude example plugin from dist

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -15,6 +15,7 @@
 /CONTRIBUTING.md export-ignore
 /phpcs.xml export-ignore
 /phpcs.xml.dist export-ignore
+/plugins/tgm-example-plugin.zip export-ignore
 
 #
 # Auto detect text files and perform LF normalization


### PR DESCRIPTION
Github uses `git archive` to produce the automatic dist archive. This archive is what is downloaded when Composer retrieves the dependency by default or with `prefer-dist`. By adding this line, the plugin archive is excluded from dist because it is an example that is never needed in dist environments (like production), reducing download size and time.